### PR TITLE
Better plotting API and Evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Documentation Status](https://readthedocs.org/projects/celltk/badge/?version=docs2)](https://celltk.readthedocs.io/en/docs2/?badge=docs2)
+[![Documentation Status](https://readthedocs.org/projects/celltk/badge/?version=latest)](https://celltk.readthedocs.io/en/latest/?badge=latest)
 [![pytest](https://github.com/sjeknic/CellTK/actions/workflows/main.yml/badge.svg)](https://github.com/sjeknic/CellTK/actions/workflows/main.yml)
 
 

--- a/celltk/__init__.py
+++ b/celltk/__init__.py
@@ -9,6 +9,7 @@ from .process import Processor
 from .segment import Segmenter
 from .track import Tracker
 from .extract import Extractor
+from .evaluate import Evaluator
 
 # Import important types
 from .utils.utils import ImageHelper

--- a/celltk/core/arrays.py
+++ b/celltk/core/arrays.py
@@ -10,7 +10,6 @@ import plotly.graph_objects as go
 import matplotlib.pyplot as plt
 
 import celltk.utils.filter_utils as filtu
-from celltk.utils.plot_utils import plot_groups, plot_trace_predictions
 from celltk.utils.info_utils import nan_helper_2d, get_split_idxs, split_array
 from celltk.utils.unet_model import UPeakModel
 from celltk.utils.peak_utils import (segment_peaks_agglomeration,
@@ -1552,6 +1551,9 @@ class ExperimentArray():
         conditions passed.
 
         NOTE:
+            - As of version 0.3.0, this function is not implemented
+
+        NOTE:
             - Plotting should still be considered in the beta-stage.
               Bugs may exist. The API of this function will likely
               change and/or be replaced in the near future.
@@ -1597,6 +1599,7 @@ class ExperimentArray():
         TODO:
             - More generic way to group conditions
         """
+        raise NotImplementedError('Please use plot_utils.PlotHelper for plotting.')
         # Get the data to plot
         keys = tuple(keys) if not isinstance(keys, tuple) else keys
         if not conditions: return go.Figure()
@@ -1629,39 +1632,6 @@ class ExperimentArray():
                 fig.write_image(save)
 
         return fig
-
-    def plot_peak_predictions(self,
-                              keys: Tuple[str],
-                              conditions: Collection[str] = None,
-                              estimator: Union[Callable, str, functools.partial] = None,
-                              title: str = None,
-                              x_label: str = None,
-                              y_label: str = None,
-                              x_limit: Tuple[float] = None,
-                              y_limit: Tuple[float] = None,
-                              layout_spec: dict = {},
-                              show: bool = False,
-                              save: str = None
-                              ) -> plt.Figure:
-        """Use celltk.utils.plot_utils.plot_trace_predictions() instead.
-        Not currently well implemented.
-        """
-        # Get the data to plot
-        keys = tuple(keys) if not isinstance(keys, tuple) else keys
-        conditions = conditions if conditions else self.conditions
-        arrs = self[conditions][keys]
-        # TODO: This needs to use get key components
-        slope = self[conditions]['slope_prob', 'fitc']
-        plate = self[conditions]['plateau_prob', 'fitc']
-        preds = [s + p for s, p in zip(slope, plate)]
-        time = self.time[0]
-
-        for cidx, (arr, pred) in enumerate(zip(arrs, preds)):
-            condition = conditions[cidx]
-            for nidx, fig in enumerate(plot_trace_predictions(arr, pred, y_limit=(1000, 5000))):
-                name = f'{condition}_{nidx}_{save}'
-                plt.savefig(name)
-                plt.close()
 
     @classmethod
     def _build_from_file(cls, f: h5py.File) -> 'ExperimentArray':

--- a/celltk/core/arrays.py
+++ b/celltk/core/arrays.py
@@ -1051,7 +1051,7 @@ class ExperimentArray():
     @property
     def ndim(self):
         """Returns list of the number of dimensoins of each ConditionArray."""
-        return [v.ndim for v in self.sites.values()]
+        return next(iter(self.sites.values())).ndim
 
     @property
     def dtype(self):
@@ -1066,22 +1066,22 @@ class ExperimentArray():
     @property
     def regions(self):
         """Returns list of the names of the regions in each ConditionArray."""
-        return [v.regions for v in self.sites.values()]
+        return next(iter(self.sites.values())).regions
 
     @property
     def channels(self):
         """Returns list of the names of the channels in each ConditionArray."""
-        return [v.channels for v in self.sites.values()]
+        return next(iter(self.sites.values())).channels
 
     @property
     def metrics(self):
         """Returns list of the names of the metrics in each ConditionArray."""
-        return [v.metrics for v in self.sites.values()]
+        return next(iter(self.sites.values())).metrics
 
     @property
     def time(self):
         """Returns list of the time axis of each ConditionArray."""
-        return [v.time for v in self.sites.values()]
+        return next(iter(self.sites.values())).time
 
     @property
     def coordinates(self):

--- a/celltk/core/orchestrator.py
+++ b/celltk/core/orchestrator.py
@@ -378,8 +378,10 @@ class Orchestrator():
                          f'to {len(self)} Pipelines.')
         for pipe, kwargs in self.pipelines.items():
             # If Extractor is in operations, update the condition
-            op = {k: v for k, v in op_dict.items()
-                  if 'extractor' not in k}
+            # NOTE: This dictionary must preserve order
+            op = {k if 'extractor' not in k else 'extractor':
+                  v if 'extractor' not in k else {}
+                  for k, v in op_dict.items()}
             # TODO: This could be done outside of the outer loop
             for opname in op_dict:
                 if 'extractor' in opname:

--- a/celltk/core/pipeline.py
+++ b/celltk/core/pipeline.py
@@ -338,7 +338,7 @@ class Pipeline():
             save_folder = os.path.join(self.output_folder, name)
 
             # Save CellArray separately
-            if oper_output == 'array':
+            if otpt_type == 'array':
                 name = os.path.join(self.output_folder, f"{name}.hdf5")
                 arr.save(name)
 

--- a/celltk/evaluate.py
+++ b/celltk/evaluate.py
@@ -1,0 +1,31 @@
+import numpy as np
+
+from celltk.utils._types import Track, Mask, Image, Arr
+from celltk.core.operation import BaseEvaluator
+from celltk.utils.utils import ImageHelper
+from celltk.utils.operation_utils import track_to_mask
+
+
+class Evaluator(BaseEvaluator):
+    @ImageHelper(by_frame=False)
+    def save_kept_cells(self,
+                        track: Track,
+                        array: Arr
+                        ) -> Track:
+        """"""
+        # Figure out all the cells that were missing
+        all_cells = np.unique(track)
+        kept_cells = np.unique(array[:, :, 'label']).astype(int)
+        missing_cells = set(all_cells).difference(kept_cells)
+
+        # Change to mask to also blank negatives
+        out = track_to_mask(track)
+        for cell in missing_cells:
+            out[track == cell] = 0
+
+        # Add back the parent labels
+        parents = np.unique(track[track < 0])
+        for par in parents:
+            np.where(np.logical_and(track == par, track > 0), par, out)
+
+        return out

--- a/celltk/evaluate.py
+++ b/celltk/evaluate.py
@@ -1,9 +1,13 @@
+import warnings
+from typing import Tuple
+
 import numpy as np
 
 from celltk.utils._types import Track, Mask, Image, Arr
 from celltk.core.operation import BaseEvaluator
 from celltk.utils.utils import ImageHelper
 from celltk.utils.operation_utils import track_to_mask
+from celltk.utils.info_utils import nan_helper_1d
 
 
 class Evaluator(BaseEvaluator):
@@ -27,5 +31,62 @@ class Evaluator(BaseEvaluator):
         parents = np.unique(track[track < 0])
         for par in parents:
             np.where(np.logical_and(track == par, track > 0), par, out)
+
+        return out
+
+    @ImageHelper(by_frame=False, as_tuple=False)
+    def make_single_cell_stack(self,
+                               image: Image,
+                               array: Arr,
+                               cell_id: int,
+                               position_id: int = None,
+                               window_size: Tuple[int] = (40, 40),
+                               region: str = None,
+                               channel: str = None
+                               ) -> Image:
+        """
+        Should make a montage and follow the centroid of a single cell
+
+        NOTE:
+            - Cells very close to edge might raise IndexError
+        """
+        # Simpler if it's limited to even numbers only
+        assert all([not (w % 2) for w in window_size])
+
+        # Find the centroid for the cell in question
+        region = array.regions[0] if not region else region
+        channel = array.channels[0] if not channel else channel
+        cell_index = np.where(array[region, channel, 'label'] == cell_id)[0]
+        if len(np.unique(cell_index)) > 1:
+            # Greater than one instance found
+            if position_id:
+                # Get it based on the position
+                pass
+            else:
+                warnings.warn('Found more than one matching cell. Using '
+                              f'first instance found at {cell_index[0]}.')
+                cell_index = int(cell_index[0])
+        else:
+            cell_index = int(cell_index[0])
+
+        # Get the centroid, window for the cell, and img size
+        y, x = array[region, channel, ('y', 'x'), cell_index, :]
+        y = nan_helper_1d(y)
+        x = nan_helper_1d(x)
+        frames, y_img, x_img = image.shape
+        x_win, y_win = window_size
+
+        # Make the window with the cell in the center of the window
+        x_adj = int(x_win / 2)
+        y_adj = int(y_win / 2)
+        y_min = np.floor(np.clip(y - y_adj, a_min=0, a_max=None)).astype(int)
+        y_max = np.floor(np.clip(y + y_adj, a_min=None, a_max=y_img)).astype(int)
+        x_min = np.floor(np.clip(x - x_adj, a_min=0, a_max=None)).astype(int)
+        x_max = np.floor(np.clip(x + x_adj, a_min=None, a_max=x_img)).astype(int)
+
+        out = np.empty((frames, y_win, x_win), dtype=image.dtype)
+        for fr in range(frames):
+            fr = int(fr)
+            out[fr, ...] = image[fr, y_min[fr]:y_max[fr], x_min[fr]:x_max[fr]]
 
         return out

--- a/celltk/track.py
+++ b/celltk/track.py
@@ -575,7 +575,8 @@ class Tracker(BaseTracker):
             lineage = np.vstack(tracker.lbep)[:, :4]
 
             # Convert mask labels before writing lineage
-            new_mask = bayes_extract_tracker_data(bayes_id_mask, tracker)
+            tracks = [t['ID'] for t in tracker.tracks]
+            new_mask = bayes_extract_tracker_data(bayes_id_mask, tracks, tracker.refs)
 
         return lineage_to_track(new_mask, lineage)
 

--- a/celltk/utils/bayes_utils.py
+++ b/celltk/utils/bayes_utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-import btrack
 
 from celltk.utils._types import Mask
 
@@ -13,7 +12,7 @@ def bayes_update_mask(mask: Mask, objects: list) -> np.ndarray:
 
     Assume that regionprops goes through labels in order
     """
-    out = np.ones(mask.shape, dtype=np.int16) * -1
+    out = np.ones(mask.shape, dtype=np.int32) * -1
     # Iterate through all frames in mask
     for t, frame in enumerate(mask):
         old_labels = np.unique(frame[frame > 0])
@@ -29,17 +28,23 @@ def bayes_update_mask(mask: Mask, objects: list) -> np.ndarray:
 
 
 def bayes_extract_tracker_data(mask: Mask,
-                               tracker: btrack.BayesianTracker
+                               tracks: np.ndarray,
+                               references: np.ndarray
                                ) -> Mask:
+    """Updates labels in the given mask to match tracker references.
+    bayesian_tracker first uniquely identifies all objects (mask). Then
+    assigns real labels (tracks) to match the unique labels (references).
+    This function produces a new mask with tracks as the labels.
     """
-    Update labels in mask to match the tracker references
+    # Flatten the input array for easier search
+    ravel = mask.ravel()
 
-    TODO:
-        - This function seems surprisingly slow
-    """
-    out = np.zeros_like(mask)
-    for btrk, bref in zip(tracker.tracks, tracker.refs):
-        trk_obs = np.isin(mask, [b for b in bref if b >= 0])
-        out[trk_obs] = btrk['ID']
+    # Build mapping dictionar
+    mapping = {}
+    for btrk, bref in zip(tracks, references):
+        for b in bref:
+            if b > 0: mapping[b] = btrk[0]
 
-    return out
+    # Build output array and then reshape
+    out = [mapping.get(r, 0) for r in ravel]
+    return np.asarray(out).reshape(mask.shape)

--- a/celltk/utils/estimator_utils.py
+++ b/celltk/utils/estimator_utils.py
@@ -52,7 +52,7 @@ def wilson_score(arr: np.ndarray,
     prob = np.squeeze(fraction_of_total(arr, ax=ax))
 
     # Get cell counts for each column
-    n = (~np.isnan(arr)).sum(0)
+    n = (~np.isnan(arr)).sum(ax)
 
     # Calculate the wilson score
     denom = 1 + z ** 2 / n
@@ -63,3 +63,19 @@ def wilson_score(arr: np.ndarray,
     lo = (adj_prob - z * adj_sd) / denom
 
     return np.vstack([hi, lo])
+
+
+def normal_approx(arr: np.ndarray,
+                  ci: float = 0.95,
+                  ax: int = 0
+                  ) -> np.ndarray:
+    """"""
+    # Do two-tailed by default, so divide by 2
+    z = stats.norm.ppf(1 - (1 - ci) / 2)
+
+    # Get proportion of population that is positive
+    prob = np.squeeze(fraction_of_total(arr, ax=ax))
+    # Get cell counts
+    n = (~np.isnan(arr)).sum(ax)
+
+    return z * np.sqrt((prob * (1 - prob)) / n)

--- a/celltk/utils/metric_utils.py
+++ b/celltk/utils/metric_utils.py
@@ -2,10 +2,10 @@ from typing import Union, Tuple
 
 import numpy as np
 import scipy.stats as stats
+import scipy.integrate as integrate
 import matplotlib.pyplot as plt
 
 from celltk.utils.unet_model import UPeakModel
-from celltk.utils.plot_utils import plot_trace_predictions
 
 
 def median_intensity(mask: np.ndarray, image: np.ndarray) -> float:
@@ -52,8 +52,6 @@ def predict_peaks(array: np.ndarray,
                   segment: bool = True,
                   roi: Union[int, Tuple[int]] = (1, 2),
                   save_path: str = None,
-                  save_plot: str = None,
-                  show_plot: bool = False
                   ) -> None:
     """Predicts peaks in arbitrary data using UPeak.
 
@@ -69,7 +67,11 @@ def predict_peaks(array: np.ndarray,
     :param save_plot: If a string is provided, saves output figures using the given
         figure name. Do not provided extension in file name, figures can currently
         only be saved as png.
-    :param show_plot:
+    :param show_plot: If True, plot will be shown to the user.
+
+
+    TODO:
+        - Add ability to specify an arbitrary model structure.
     """
     # Get model
     model = UPeakModel(weight_path)
@@ -82,11 +84,5 @@ def predict_peaks(array: np.ndarray,
     # Save the outputs
     if save_path:
         np.save(save_path, predictions)
-
-    if save_plot or show_plot:
-        for fidx, fig in enumerate(plot_trace_predictions(array, predictions)):
-            if save_plot: plt.savefig(fig, f'{save_plot}_{fidx}.png')
-            if show_plot: plt.show()
-            plt.close(fig)
 
     return predictions

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -13,408 +13,338 @@ import colorcet as cc
 
 import celltk.utils.estimator_utils
 
-"""
-Need some notes for myself, because this is still very hackish, but I
-don't have a good idea of how I'd rather set it up. I do know that I want
-to be able to make a variety of plots. And instead of passing errors and arrs
-around everywhere, they probably only apply to certain plots...
 
-Plotting functions I want:
-    - lines
-    - lines + shaded area (e.g. sns.tsplot)
-    - lines + shaded lines (e.g. eidos model traces)
-    - scatter
-    - scatter cluster
-    - distributions
+class PlotHelper:
 
+    '''
+    Okay, I don't know what the fuck I'm doing anymore. I have to do something, but
+    don't want to do anything and have no fucking clue how to structure this. I know
+    as soon as I start, I'll fuck it up and realize I should have done it differently.
 
-Need easier way to specify:
-    = line colors
-    - conditions (maybe in array can have conditions_2_keys or something??)
+    Anyways, the general steps are:
+    1) User provides the data arrays to plot
+    2) User provides the type of plot
+    3) User provides colors, labels, and other figure params
 
-"""
-def plot_groups(arrs: Collection[np.ndarray],
-                keys: Collection[str] = [],
-                estimator: Union[Callable, str, functools.partial] = None,
-                err_estimator: Union[Callable, str, functools.partial] = None,
-                colors: (str, Collection) = [],
-                kind: str = 'line',
-                time: np.ndarray = None,
-                legend: bool = True,
-                template: str = None,
-                figure_spec: dict = {},
-                figure: go.Figure = None,
-                *args, **kwargs
-                ) -> go.Figure:
-    """
-    Wrapper for plotly functions
+    3.9) Plotter saves information about input data (e.g. cell nums)
+    4) Plotter formats data arrays as needed
+        - Applies estimator
+        - Applies error estimator
+        - Collects cells, etc.
+    5) Plotter starts figure and applies lines
+    6) Plotter returns figures
+    '''
+    # Establishing the default format
+    _template = 'simple_white'
+    _font_families = "Graphik,Roboto,Helvetica Neue,Helvetica,Arial"
+    _ax_col = '#444'
+    _black = '#000000'
+    _default_axis_layout = {
+            'layer': 'above traces',
+            'linewidth': 3,
+            'linecolor': _ax_col,
+            'showline': True,
+            'tickfont': dict(color=_ax_col, size=12, family=_font_families),
+            'ticklen': 7,
+            'ticks': 'outside',
+            'tickwidth': 2,
+            'title': dict(font=dict(color='#242424', size=20)),
+            'zeroline': False,
+        }
+    _default_legend_layout = {
+            'borderwidth': 0,
+            'font': dict(color=_ax_col, size=12, family=_font_families),
+            'itemsizing': 'constant',
+            'itemwidth': 30,  # must be >= 30
+            'title': {'font': dict(color=_ax_col, size=12,
+                                   family=_font_families)},
+            'tracegroupgap': 10,  # must be >= 0
+        }
 
-    Assume each row in arr is a sample
+    # kwarg keys
+    _line_kwargs = ('color', 'dash', 'shape', 'simplify', 'smoothing', 'width')
+    _violin_kwargs = ('bandwidth', 'fillcolor', 'hoverinfo', 'jitter', 'marker',
+                      'line', 'opacity', 'pointpos', 'points', 'span', 'width')
 
-    TODO:
-        - This is currently set up a bit more like a private function
-    """
-    # Get the plotting function
-    try:
-        plot_func = PLT_FUNCS[kind]
-    except KeyError:
-        raise KeyError(f'Could not find function {kind}.')
-
-    # Get the color scale to use
-    # colorscale = getattr(pcol.qualitative, DEF_COLORS)
-    colorscale = itertools.cycle((cc.glasbey_dark))
-    if colors:
-        if isinstance(colors, str):
-            # TODO: This won't work well for discrete colorscales
-            # colorscale = itertools.cycle(pcol.get_colorscale(colors))
-            colorscale = itertools.cycle(sns.color_palette(colors, len(arrs)))
-        elif isinstance(colors, (list, tuple)):
-            colorscale  = itertools.cycle(colors)
-
-
-    # Make the plot and add the data
-    fig = figure if figure else go.Figure()
-    for idx, data in enumerate(itertools.zip_longest(arrs, keys)):
-        arr, key = data
-
-        # Add the number of cells used to the legend label
-        if not key:
-            key = idx
-        key += f' | n={arr.shape[0]}'
-
-        # Need to calculate error before estimating arr
-        if err_estimator:
-            err_arr = _apply_estimator(arr, err_estimator)
+    def _build_colormap(self,
+                        colors: Union[str, Collection[str]],
+                        number: int
+                        ) -> Generator:
+        """Returns an infinite color generator for an arbitrary
+        colormap or colorscale."""
+        if colors is None:
+            _col = cc.glasbey_dark
+        elif isinstance(colors, (list, tuple, np.ndarray)):
+            _col = colors
         else:
-            err_arr = None
-
-        arr = _apply_estimator(arr, estimator)
-
-        # Add information to figure
-        kwargs.update({'color': _format_colors(next(colorscale))})
-        fig = plot_func(fig, arr, err_arr, key, time, *args, **kwargs)
-
-    # Update figure after it is made
-    template = template if template else DEF_TEMPLATE
-    fig.update_layout(showlegend=legend, template=template, **figure_spec)
-
-    return fig
-
-
-def get_timeseries_estimator(func: Union[Callable, str],
-                             *args, **kwargs
-                             ) -> functools.partial:
-    """Returns Callable object that will be applied over time axis
-
-    Args:
-        func: The function to make the estimator from. If str, looks
-            for the function in numpy. Otherwise, uses np.apply_along_axis.
-
-    Returns:
-        functools.partial object of the estimator
-
-    TODO:
-        - Should have the option to look for already made estimators
-    """
-    # Remove axis kwarg from kwargs
-    kwargs = {k: v for k, v in kwargs.items() if k != 'axis'}
-
-    if isinstance(func, str):
-        try:
-            func = getattr(celltk.utils.estimator_utils, func)
-            return functools.partial(func, *args, **kwargs)
-        except AttributeError:
+            # Check in a few places
             try:
-                func = getattr(np, func)
-                return functools.partial(func, axis=0, *args, **kwargs)
+                _col = sns.color_palette(colors, number)
+            except ValueError:
+                try:
+                    # Try getting it from plotly
+                    _col = pcol.get_colorscale(colors)
+                    _col = pcol.colorscale_to_colors(_col)
+                except Exception:  # This will be PlotlyError, find it
+                    raise ValueError(f'Could not get colorscale for {colors}')
+
+        _col = [self._format_colors(c) for c in _col]
+        return itertools.cycle(_col)
+
+    @staticmethod
+    def _format_colors(color: str, alpha: float = None) -> str:
+        """Converst hexcode colors to RGBA to allow transparency"""
+        if isinstance(color, (list, tuple)):
+            if all([isinstance(f, (float, int)) for f in color]):
+                # Assume rgb
+                if alpha: color += (alpha, )
+                else: color += (1.,)
+                color_str = str(tuple([c for c in color]))
+            else:
+                # Assume first value is alpha
+                alpha = alpha if alpha else color[0]
+                if alpha < 0.125: alpha = 0.125
+                values = pcol.unlabel_rgb(color[1]) + (alpha,)
+                color_str = str(tuple([c for c in values]))
+
+            return f'rgba{color_str}'
+        elif isinstance(color, str):
+            # Convert hex to rgba
+            if color[0] == '#':
+                color = pcol.hex_to_rgb(color)
+                if alpha:
+                    color += (alpha,)
+                color_str = str(tuple([c for c in color]))
+                if len(color) == 4:
+                    return f'rgba{color_str}'
+                else:
+                    return f'rgb{color_str}'
+
+            else:
+                assert color[:3] in ('rgb')  # only rgb for now I think
+                if alpha:
+                    # extract the rgb values
+                    vals = pcol.unlabel_rgb(color)
+                    vals += (alpha, )
+                    color_str = str(tuple([v for v in vals]))
+                    color = f'rgba{color_str}'
+
+                return color
+
+    def _build_estimator_func(self,
+                              func: Union[Callable, str, functools.partial],
+                              *args, **kwargs
+                              ) -> functools.partial:
+        if isinstance(func, functools.partial):
+            # Assume user already made the estimator
+            return func
+        elif isinstance(func, Callable):
+            return functools.partial(np.apply_along_axis, func, 0)
+        elif isinstance(func, str):
+            try:
+                func = getattr(celltk.utils.estimator_utils, func)
+                return functools.partial(func, *args, **kwargs)
             except AttributeError:
-                raise ValueError(f'Did not understand estimator {func}')
+                try:
+                    func = getattr(np, func)
+                    return functools.partial(func, axis=0, *args, **kwargs)
+                except AttributeError:
+                    raise ValueError(f'Did not understand estimator {func}')
 
-    else:
-        # Need to pass positionally to make it easier to call later
-        return functools.partial(np.apply_along_axis, func, 0,
-                                 *args, **kwargs)
+    def line_plot(self,
+                  arrays: Collection[np.ndarray],
+                  keys: Collection[str] = [],
+                  estimator: Union[Callable, str, functools.partial] = None,
+                  err_estimator: Union[Callable, str, functools.partial] = None,
+                  colors: Union[str, Collection[str]] = None,
+                  time: np.ndarray = None,
+                  legend: bool = True,
+                  figure: go.Figure = None,
+                  title: str = None,
+                  x_label: str = None,
+                  y_label: str = None,
+                  x_limit: Tuple[float] = None,
+                  y_limit: Tuple[float] = None,
+                  *args, **kwargs
+                  ) -> Union[go.Figure, go.FigureWidget]:
+        """"""
+        # Format inputs
+        assert all([isinstance(a, np.ndarray) for a in arrays])
+        assert all([a.ndim == 2 for a in arrays])
 
+        # Convert any inputs that need converting
+        colors = self._build_colormap(colors, len(arrays))
+        if estimator: estimator = self._build_estimator_func(estimator)
+        if err_estimator: err_estimator = self._build_estimator_func(err_estimator)
+        line_kwargs = {k: v for k, v in kwargs.items()
+                       if k in self._line_kwargs}
+        kwargs = {k: v for k, v in kwargs.items()
+                  if k not in self._line_kwargs}
 
-def plot_trace_predictions(traces: np.ndarray,
-                           predictions: np.ndarray,
-                           roi: Union[int, Tuple[int]] = None,
-                           cmap: str = 'plasma',
-                           color_limit: Tuple[int] = (0, 1),
-                           y_limit: Tuple[int] = None,
-                           ) -> plt.Figure:
-    """"""
-    rows, cols = (8, 4)
-    size = (11.69, 8.27)  # inches, sheet of paper
-    num_figs = int(np.ceil(traces.shape[0] / (rows * cols)))
+        # Build the figure and start plotting
+        fig = figure if figure else go.Figure()
+        for idx, (arr, key) in enumerate(itertools.zip_longest(arrays, keys)):
+            # Get the key
+            if not key:
+                key = f'line_{idx}'
+            key += f' | n={arr.shape[0]}'
 
-    # Sum the prediction values
-    if roi and predictions.ndim == 3:
-        predictions = predictions[..., roi]
-    elif predictions.ndim == 3:
-        predictions = np.nansum(predictions, axis=-1)
-
-    # Iterate over all the needed figures
-    trace_idx = 0
-
-    for fidx in range(num_figs):
-        fig, ax = plt.subplots(rows, cols, figsize=size,
-                               sharey=True, sharex=True)
-
-        # Iterate over all the axes in the figure and plot
-        for a in ax.flatten():
-            try:
-                line = _make_single_line_collection(traces[trace_idx],
-                                                    predictions[trace_idx],
-                                                    cmap, color_limit)
-                line.set_linewidth(2)
-                line = a.add_collection(line)
-                trace_idx += 1
-            except IndexError:
-                # All of the traces have been used
-                break
-
-        # Set up the plots
-        plt.setp(ax, xlim=(0, traces.shape[1]), ylim=y_limit)
-        fig.colorbar(line, ax=ax)
-
-        yield fig
-
-
-def _apply_estimator(arr: np.ndarray,
-                     estimator: Union[Callable, str, functools.partial] = None,
-                     ) -> np.ndarray:
-    """"""
-    if estimator:
-        arr = arr.copy()
-        if isinstance(estimator, functools.partial):
-            # Assume that the estimator is ready to go
-            arr = estimator(arr)
-        elif isinstance(estimator, (Callable, str)):
-            estimator = get_timeseries_estimator(estimator)
-            arr = estimator(arr)
-        else:
-            raise TypeError(f'Did not understand estimator {estimator}')
-
-    return arr
-
-
-def _line_plot(fig: go.Figure,
-               arr: np.ndarray,
-               err_arr: np.ndarray = None,
-               label: str = None,
-               time: np.ndarray = None,
-               *args, **kwargs
-               ) -> go.Figure:
-    """Wrapper for go.Scatter
-
-    https://plotly.com/python/continuous-error-bars/
-    """
-    kwargs, line_kwargs = _parse_kwargs_for_plot_type('line', kwargs)
-    # line_kwargs['color'] = _fmt_
-    # TODO: Not sure how to handle this yet...
-    x = time if time is not None else np.arange(arr.shape[0])
-    # plots one at a time, so arr must be 2D
-    if arr.ndim == 1: arr = np.expand_dims(arr, 0)
-
-    # Set up plot
-    lines = []
-    showlegend = True
-    for idx, y in enumerate(arr):
-        # Legend is only shown for the first line
-        if idx:
-            showlegend = False
-
-        lines.append(
-            go.Scatter(x=x, y=y, legendgroup=label,
-                       showlegend=showlegend, mode='lines',
-                       line=line_kwargs,
-                       name=label, *args, **kwargs)
-        )
-
-        if err_arr is not None:
-            # TODO: Are there other forms err_arr could take?
-            if err_arr.ndim == 1:
-                # Assume it's both high and low
-                hi = np.nansum([y, err_arr], axis=0)
-                lo = np.nansum([y, -err_arr], axis=0)
+            # err_estimator is used to set the bounds for the shaded region
+            if err_estimator:
+                err_arr = err_estimator(arr)
             else:
-                lo = err_arr[0, :]
-                hi = err_arr[-1, :]
+                err_arr = None
 
-            lines.append(
-                go.Scatter(x=np.hstack([x, x[::-1]]),
-                           y=np.hstack([hi, lo[::-1]]), fill='tozerox',
-                           fillcolor=_format_colors(line_kwargs['color'], 0.25),
-                           showlegend=False, legendgroup=label,
-                           name=label, line=dict(color='rgba(255,255,255,0)'),
-                           hoverinfo='skip')
-            )
+            # estimator is used to condense all the lines to a single line
+            if estimator:
+                arr = estimator(arr)
+                if arr.ndim == 1: arr = arr[None, :]
+            x = time if time is not None else np.arange(arr.shape[1])
 
-    fig.add_traces(lines)
+            lines = []
+            _legend = True
+            for a, y in enumerate(arr):
+                if a: _legend = False
+                line_kwargs.update({'color': next(colors)})
 
-    return fig
+                lines.append(
+                    go.Scatter(x=x, y=y, legendgroup=key, name=key,
+                               showlegend=_legend, mode='lines',
+                               line=line_kwargs, *args, **kwargs)
+                )
 
+                if err_arr is not None:
+                    if err_arr.ndim == 1:
+                        # Assume it's high and low deviation from y
+                        hi = np.nansum([y, err_arr], axis=0)
+                        lo = np.nansum([y, -err_arr], axis=0)
+                    else:
+                        lo = err_arr[0, :]
+                        hi = err_arr[-1, :]
 
-def _overlay_line_plot(fig: go.Figure,
-                       arr: np.ndarray,
-                       err_arr: np.ndarray,
-                       label: str = None,
-                       time: np.ndarray = None,
-                       *args, **kwargs
-                       ) -> go.Figure:
-    """"""
-    kwargs, line_kwargs = _parse_kwargs_for_plot_type('line', kwargs)
+                    lines.append(
+                        go.Scatter(x=np.hstack([x, x[::-1]]),
+                                   y=np.hstack([hi, lo[::-1]]), fill='tozerox',
+                                   fillcolor=self._format_colors(line_kwargs['color'], 0.25),
+                                   showlegend=False, legendgroup=key,
+                                   name=key, line=dict(color='rgba(255,255,255,0)'),
+                                   hoverinfo='skip')
+                        )
 
-    # TODO: Not sure how to handle this yet...
-    x = time if time is not None else np.arange(arr.shape[0])
-    # plots one at a time, so arr must be 2D
-    if arr.ndim == 1: arr = np.expand_dims(arr, 0)
+            fig.add_traces(lines)
+        fig.update_layout(template=self._template)
+        fig.update_xaxes(**self._default_axis_layout)
+        fig.update_yaxes(**self._default_axis_layout)
+        return fig
 
-    # Plot the overlay lines
-    lines = []
-    # TODO: Check shape of arr here - probably look for order of magnitude
-    # alpha = 10. / arr.shape[0]
-    alpha = 0.1
-    for idx, y in enumerate(arr):
-        # Legend is not shown for any of these lines
-
-        lines.append(
-            go.Scatter(x=x, y=y, legendgroup=label,
-                       showlegend=False, mode='lines',
-                       line=dict(color=_format_colors(line_kwargs['color'], alpha)),
-                       name=label, *args, **kwargs)
-        )
-
-    # Plot the median line
-    line_kwargs.update({'width': 5})
-    lines.append(
-        go.Scatter(x=x, y=np.nanmedian(arr, axis=0),
-                   showlegend=True, legendgroup=label, mode='lines',
-                   line=line_kwargs, name=label, *args, **kwargs)
-    )
-
-    fig.add_traces(lines)
-
-    return fig
-
-
-def _histogram_plot(fig: go.Figure,
-                    arr: np.ndarray,
-                    err_arr: np.ndarray,
-                    label: str = None,
-                    time: np.ndarray = None,
+    def violin_plot(self,
+                    arrays: Collection[np.ndarray],
+                    neg_arrays: Collection[np.ndarray] = [],
+                    keys: Collection[str] = [],
+                    neg_keys: Collection[str] = [],
+                    colors: Union[str, Collection[str]] = None,
+                    neg_colors: Union[str, Collection[str]] = None,
+                    orientation: str = 'v',
+                    show_box: bool = False,
+                    show_points: Union[str, bool] = False,
+                    spanmode: str = 'hard',
+                    legend: bool = True,
+                    figure: go.Figure = None,
+                    title: str = None,
+                    x_label: str = None,
+                    y_label: str = None,
+                    x_limit: Tuple[float] = None,
+                    y_limit: Tuple[float] = None,
                     *args, **kwargs
-                    ) -> go.Figure:
-    """"""
-    kwargs, hist_kwargs = _parse_kwargs_for_plot_type('hist', kwargs)
-    data = go.Histogram(x=np.ravel(arr), legendgroup=label, name=label, showlegend=True,
-                   marker=dict(color=_format_colors(hist_kwargs['color'], 0.8)),
-                   nbinsx=100, *args, **kwargs, histnorm='percent')
-    fig.add_traces(data)
+                    ) -> Union[go.Figure, go.FigureWidget]:
+        """"""
+        # Format inputs
+        violinmode = None
+        side = None
+        assert all([isinstance(a, np.ndarray) for a in arrays])
+        arrays = [np.squeeze(a) for a in arrays]
+        assert all([a.ndim == 1 for a in arrays])
+        if neg_arrays:
+            assert len(arrays) == len(neg_arrays)
+            neg_arrays = [np.squeeze(a) for a in neg_arrays]
+            assert all([a.ndim == 1 for a in neg_arrays])
+            violinmode = 'overlay'
+            side = 'positive'
+        assert orientation in ('v', 'h', 'horizontal', 'vertical')
 
-    fig.update_layout(barmode='group')
-    fig.update_traces(xbins=dict(start=err_arr.min(), end=err_arr.max()))
+        # Convert any inputs that need converting
+        colors = self._build_colormap(colors, len(arrays))
+        neg_colors = self._build_colormap(neg_colors, len(neg_arrays))
+        violin_kwargs = {k: v for k, v in kwargs.items()
+                         if k in self._violin_kwargs}
+        kwargs = {k: v for k, v in kwargs.items()
+                  if k not in self._violin_kwargs}
 
-    return fig
+        fig = figure if figure else go.Figure()
+        for idx, (arr, key) in enumerate(itertools.zip_longest(arrays, keys)):
+            # Get the key
+            if not key:
+                key = f'dist_{idx}'
+            key += f' | n={arr.shape[0]}'
 
+            # Set the data key based on orientation
+            if orientation in ('v', 'vertical'):
+                y = arr
+                x = None
+                if neg_arrays:
+                    neg_y = neg_arrays[idx]
+                    neg_x = None
+                    # y0 = key
+                    # x0 = None
+            elif orientation in ('h', 'horizontal'):
+                y = None
+                x = arr
+                if neg_arrays:
+                    neg_y = [key]
+                    neg_x = neg_arrays[idx]
+                    # y0 = None
+                    # x0 = key
 
-def _peak_prediction_plot(fig: go.Figure,
-                          arr: np.ndarray,
-                          err_arr: np.ndarray = None,
-                          label: str = None,
-                          time: np.ndarray = None,
-                          *args, **kwargs
-                          ) -> go.Figure:
-    """"""
+            # Set up the colors
+            _c = next(colors)
+            violin_kwargs.update({'fillcolor': _c})
+            line = {'color': _c}
 
+            # Make individual distributions on the plot
+            trace = go.Violin(x=x, y=y, name=key, legendgroup=key, side=side,
+                              spanmode=spanmode, box_visible=show_box,
+                              points=show_points, hoverinfo='skip',
+                              line=line, *args, **violin_kwargs)
+            fig.add_trace(trace)
 
-def _color_generator(colors) -> Generator:
-    """"""
-    pass
+            if neg_arrays:
+                # Set up the colors
+                _nc = next(neg_colors)
+                violin_kwargs.update({'fillcolor': _nc})
+                line = {'color': _nc}
 
-
-def _format_colors(color: str, alpha: float = None) -> str:
-    """Converst hexcode colors to RGBA to allow transparency"""
-    if isinstance(color, (list, tuple)):
-        if all([isinstance(f, (float, int)) for f in color]):
-            # Assume rgb
-            if alpha: color += (alpha, )
-            else: color += (1.,)
-            color_str = str(tuple([c for c in color]))
-        else:
-            # Assume first value is alpha
-            alpha = alpha if alpha else color[0]
-            if alpha < 0.125: alpha = 0.125
-            values = pcol.unlabel_rgb(color[1]) + (alpha,)
-            color_str = str(tuple([c for c in values]))
-
-        return f'rgba{color_str}'
-    elif isinstance(color, str):
-        # Convert hex to rgba
-        if color[0] == '#':
-            color = pcol.hex_to_rgb(color)
-            if alpha:
-                color += (alpha,)
-            color_str = str(tuple([c for c in color]))
-            if len(color) == 4:
-                return f'rgba{color_str}'
-            else:
-                return f'rgb{color_str}'
-
-        else:
-            assert color[:3] in ('rgb')  # only rgb for now I think
-            if alpha:
-                # extract the rgb values
-                vals = pcol.unlabel_rgb(color)
-                vals += (alpha, )
-                color_str = str(tuple([v for v in vals]))
-                color = f'rgba{color_str}'
-
-            return color
-
-
-def _parse_kwargs_for_plot_type(func: str, kwargs: dict) -> dict:
-    """Parses kwargs to include the ones that are specific to
-    a particular type of plot."""
-    plotly_funcs = dict(line=go.Scatter, hist=go.Histogram)
-    argnames = inspect.getargspec(plotly_funcs[func]).args
-
-    kept = {}
-    other = {}
-    for k, v in kwargs.items():
-        if k in argnames:
-            kept[k] = v
-        else:
-            other[k] = v
-
-    return kept, other
+                neg_side = 'negative' if side == 'positive' else 'positive'
+                nkey = neg_keys[idx] if neg_keys else key
+                neg_trace = go.Violin(x=neg_x, y=neg_y, side=neg_side,
+                                      name=nkey, legendgroup=key,
+                                      spanmode=spanmode, box_visible=show_box,
+                                      points=show_points, hoverinfo='skip',
+                                      line=line, *args, **violin_kwargs)
+                fig.add_trace(neg_trace)
 
 
-def _make_single_line_collection(trace: np.ndarray,
-                                 prediction: np.ndarray,
-                                 cmap: str = 'plasma',
-                                 limit: Tuple[int] = (0, 1)
-                                 ) -> pltcol.LineCollection:
-    """"""
-    # Should only get one trace and one probability
-    assert trace.ndim == 1
-    assert prediction.ndim == 1
-    assert len(trace) == len(prediction)
+        fig.update_traces(**kwargs)
+        fig.update_layout(template=self._template, violinmode=violinmode)
+        fig.update_xaxes(**self._default_axis_layout)
+        fig.update_yaxes(**self._default_axis_layout)
 
-    # Make an array of (ax0, ax1) points
-    points = np.array([np.arange(len(trace)), trace]).T.reshape(-1, 1, 2)
-    segments = np.concatenate([points[:-1], points[1:]], axis=1)
-
-    # Set up colors
-    norm = plt.Normalize(*limit)
-    line = pltcol.LineCollection(segments, cmap=cmap, norm=norm)
-
-    # Add the prediction data and return
-    line.set_array(prediction)
-    return line
+        return fig
 
 
-PLT_FUNCS = dict(line=_line_plot, overlay=_overlay_line_plot, hist=_histogram_plot, peaks=_peak_prediction_plot)
-DEF_COLORS = 'Safe'
-DEF_TEMPLATE = 'simple_white'
+
+
+
+
+
+
+

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -15,7 +15,6 @@ import celltk.utils.estimator_utils
 
 
 class PlotHelper:
-
     '''
     Okay, I don't know what the fuck I'm doing anymore. I have to do something, but
     don't want to do anything and have no fucking clue how to structure this. I know
@@ -44,21 +43,21 @@ class PlotHelper:
         'linewidth': 3,
         'linecolor': _ax_col,
         'showline': True,
-        'tickfont': dict(color=_ax_col, size=12, family=_font_families),
+        'tickfont': dict(color=_ax_col, size=18, family=_font_families),
         'ticklen': 7,
         'ticks': 'outside',
         'tickwidth': 2,
-        'title': dict(font=dict(color='#242424', size=20)),
+        'title': dict(font=dict(color='#242424', size=24)),
         'zeroline': False,
     }
     _no_line_axis = _default_axis_layout.copy()
     _no_line_axis['showline'] = False
     _default_legend_layout = {
         'borderwidth': 0,
-        'font': dict(color=_ax_col, size=12, family=_font_families),
+        'font': dict(color=_ax_col, size=18, family=_font_families),
         'itemsizing': 'constant',
         'itemwidth': 30,  # must be >= 30
-        'title': {'font': dict(color=_ax_col, size=12,
+        'title': {'font': dict(color=_ax_col, size=24,
                                family=_font_families)},
         'tracegroupgap': 10,  # must be >= 0
     }
@@ -178,7 +177,54 @@ class PlotHelper:
                   y_limit: Tuple[float] = None,
                   *args, **kwargs
                   ) -> Union[go.Figure, go.FigureWidget]:
-        """"""
+        """
+        Builds a plotly Figure object plotting lines of the given arrays. Each
+        array is interpreted as a separate condition and is plotted in a
+        different color.
+
+        :param arrays: List of arrays to plot. Assumed structure is n_cells x
+            n_features. Arrays must be two-dimensional, so if only one sample,
+            use np.newaxis or np.expand_dims.
+        :param keys: Names corresponding to the data arrays. If not provided,
+            the keys will be integers.
+        :param estimator: Function for aggregating observations from multiple
+            cells. For example, if estimator is np.mean, the mean of all of the
+            cells will be plotted instead of a trace for each cell. Can be
+            a function, name of numpy function, name of function in
+            estimator_utils, or a functools.partial object. If a function or
+            functools.partial object, should input a 2D array and return a
+            1D array.
+        :param err_estimator: Function for estimating error bars from multiple
+            cells. Can be
+            a function, name of numpy function, name of function in
+            estimator_utils, or a functools.partial object. If a function or
+            functools.partial object, should input a 2D array and return a
+            1D or 2D array. If output is 1D, errors will be symmetric
+            If output is 2D, the first dimension is used for the high
+            error and second dimension is used for the low error.
+        :param colors: Name of a color palette or map to use. Searches first
+            in seaborn/matplotlib, then in plotly to find the color map. If
+            not provided, the color map will be glasbey.
+        :param time: Time axis for the plot. Must be the same size as the
+            second dimension of arrays.
+        :param legend: If False, no legend is made on the plot.
+        :param figure: If a go.Figure object is given, will be used to make
+            the plot instead of a blank figure.
+        :param title: Title to add to the plot
+        :param x_label: Label of the x-axis
+        :param y_label: Label of the y-axis
+        :param x_limit: Initial limits for the x-axis. Can be changed if
+            the plot is saved as an HTML object.
+        :param y_limit: Initial limits for the y-axis. Can be changed if
+            the plot is saved as an HTML object.
+        :param *args:
+        :param **kwargs: Depending on name, passed to the "line" keyword
+            argument of go.Scatter or as keyword arguments for go.Scatter.
+            The following kwargs are passed to "line": 'color', 'dash',
+            'shape', 'simplify', 'smoothing', 'width', 'hoverinfo'
+
+        :return: Figure object
+        """
         # Format inputs
         assert all([isinstance(a, np.ndarray) for a in arrays])
         assert all([a.ndim == 2 for a in arrays])
@@ -244,7 +290,9 @@ class PlotHelper:
 
             fig.add_traces(lines)
         fig.update_layout(template=self._template)
+        self._default_axis_layout['title'].update({'text': x_label})
         fig.update_xaxes(**self._default_axis_layout)
+        self._default_axis_layout['title'].update({'text': y_label})
         fig.update_yaxes(**self._default_axis_layout)
         return fig
 
@@ -266,7 +314,56 @@ class PlotHelper:
                  y_limit: Tuple[float] = None,
                  *args, **kwargs
                  ) -> Union[go.Figure, go.FigureWidget]:
-        """"""
+        """Builds a plotly Figure object plotting bars from the given arrays. Each
+        array is interpreted as a separate condition and is plotted in a
+        different color.
+
+        :param arrays: List of arrays to plot. Assumed structure is n_cells x
+            n_features. Arrays must be two-dimensional, so if only one sample,
+            use np.newaxis or np.expand_dims.
+        :param keys: Names corresponding to the data arrays. If not provided,
+            the keys will be integers.
+        :param estimator: Function for aggregating observations from multiple
+            cells. For example, if estimator is np.mean, the mean of all of the
+            cells will be plotted instead of a bar for each cell. Can be
+            a function, name of numpy function, name of function in
+            estimator_utils, or a functools.partial object. If a function or
+            functools.partial object, should input a 2D array and return a
+            1D array.
+        :param err_estimator: Function for estimating error bars from multiple
+            cells. Can be
+            a function, name of numpy function, name of function in
+            estimator_utils, or a functools.partial object. If a function or
+            functools.partial object, should input a 2D array and return a
+            1D or 2D array. If output is 1D, errors will be symmetric
+            If output is 2D, the first dimension is used for the high
+            error and second dimension is used for the low error.
+        :param colors: Name of a color palette or map to use. Searches first
+            in seaborn/matplotlib, then in plotly to find the color map. If
+            not provided, the color map will be glasbey.
+        :param orientation: Orientation of the bar plot.
+        :param barmode: Keyword argument describing how to group the bars.
+            Options are 'group', 'overlay', 'relative', and .... See plotly
+            documentation for more details.
+        :param legend: If False, no legend is made on the plot.
+        :param figure: If a go.Figure object is given, will be used to make
+            the plot instead of a blank figure.
+        :param title: Title to add to the plot
+        :param x_label: Label of the x-axis
+        :param y_label: Label of the y-axis
+        :param x_limit: Initial limits for the x-axis. Can be changed if
+            the plot is saved as an HTML object. Only applies if orientation
+            is horizontal.
+        :param y_limit: Initial limits for the y-axis. Can be changed if
+            the plot is saved as an HTML object. Only applies if orientation
+            is veritcal.
+        :param *args:
+        :param **kwargs: Depending on name, passed to go.Bar or to
+            go.Figure.update_traces(). The following kwargs are passed to
+            go.Bar: 'hoverinfo', 'marker', 'width'.
+
+        :return: Figure object
+        """
         # Format data
         assert all([isinstance(a, np.ndarray) for a in arrays])
         assert orientation in ('v', 'h', 'horizontal', 'vertical')

--- a/celltk/utils/utils.py
+++ b/celltk/utils/utils.py
@@ -191,6 +191,8 @@ class ImageHelper():
             except (AttributeError, AssertionError):
                 # Indicates not CellTK type
                 continue
+            except KeyError as e:
+                raise KeyError(f'Invalid keyword arg for {self.func}: {e}')
 
             if self.as_tuple:
                 # No trimming of inputs is done if as_tuple
@@ -265,7 +267,8 @@ class ImageHelper():
                    self.expected_optional)
         for exp_name, exp_typ, opt in _zip:
             if (not opt) * (exp_typ in INPT_NAMES) * (exp_name not in kwargs):
-                kwargs[exp_name] = img_lists[exp_typ]
+                if img_lists[exp_typ]:
+                    kwargs[exp_name] = img_lists[exp_typ]
 
         return kwargs
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 setuptools>=41.2.0
-tensorflow==2.7.0
-numpy==1.20.3
+tensorflow>=2.7.0,<2.8.0
+numpy>=1.20,<1.21.0
 scipy>=1.6.3
 scikit_learn>=1.0.1
 scikit_image>=0.19.1
 matplotlib>=3.4.1
 plotly>=5.6.0
 pandas>=1.3.1
-cvxopt==1.2.7
+cvxopt~=1.2.7
 gurobipy>=9.5.0
 h5py>=3.6.0
 imageio>=2.13.0
@@ -18,8 +18,8 @@ SimpleITK>=2.1.1
 tifffile>=2021.11.2
 Bottleneck>=1.3.2
 btrack>=0.4.2
-colorcet==3.0.0
+colorcet~=3.0.0
 umap~=0.1.1
 hdbscan~=0.8.28
 seaborn~=0.11.2
-pytest==7.0.1
+pytest~=7.0.1

--- a/tests/upeak_test.py
+++ b/tests/upeak_test.py
@@ -12,7 +12,6 @@ import pytest
 import celltk
 import celltk.utils.unet_model
 from celltk.utils.peak_utils import segment_peaks_agglomeration
-from celltk.utils.plot_utils import plot_trace_predictions
 
 class TestUPeak():
     weight_path = "celltk/config/upeak_example_weights.tf"
@@ -34,7 +33,6 @@ class TestUPeak():
 
         # Predict and plot
         out = upeak.predict(arr, roi=(0, 1, 2))
-        plot_trace_predictions(arr, out[..., 1:])
 
 
 class TestPeakSegmentation():


### PR DESCRIPTION
This PR introduces some major changes to how plotting is done and some helpful functions in Evaluator.

**NEW**
- A `PlotHelper` class is added in `celltk.utils.plot_utils`. This will be the plotting API going forward and should hopefully be a little more flexible. Currently includes line plots, bar plots, and violin plots. More will come soon. `ExperimentArray.plot_by_conditions` now raises `NotImplementedError` until I can implement something using the new API. 
- The `Evaluator` class makes a comeback! It now includes a couple helper functions with more to come. `save_kept_cells` will save a mask of only the cells that ended up in the final array and `make_single_cell_stack` will crop the images to follow a single cell, useful for making montages.
- Added a couple more metrics (wilson and normal) to `estimator_utils`. Good for binomial distributions.

**Improvements**
- `bayesian_tracker` is now much faster. Specifically, one of the postprocessing steps (part of CellTK, not btrack) was using `np.isin` which caused a huge slowdown. Now it's improved to use dictionaries and list comprehensions. Even faster than a previous version I wrote that uses `numba`.
- Certain properties (like `regions` and `channels`) are assumed to be shared by all `ConditionArrays`. As such, asking for those properties from `ExperimentArray` now returns only the first instance.

**Bug Fixes**
- `Pipeline` can now load `hdf5` files. Addresses #80.
- A bug in `ImageHelper` would allow empty lists to pass to required keyword arguments, preventing an error from being raised that a required input is missing. This is now fixed.
- Adding `Evaluator` revealed a bug that could cause `Extractor` operations to be out of order in `Pipeline`. This would only happen when calling from `Orchestrator` and was due to remaking the `Extractor` dictionary with a new condition. This is fixed.
- Adding `Evaluator` also revealed a bug where the `Operation` output type would take preference over the function output type for saving images in some cases. This is also fixed.
- The documentation `README` badge now points to the correct documentation.