### PR TITLE
V033

### DIFF
--- a/celltk/core/arrays.py
+++ b/celltk/core/arrays.py
@@ -1204,6 +1204,9 @@ class ExperimentArray():
                 else:
                     f[key].attrs[coord] = val.coords[coord]
 
+            f[key].attrs['time'] = val.time
+            f[key].attrs['pos_id'] = val.pos_id
+
         f.close()
 
     @classmethod

--- a/celltk/core/operation.py
+++ b/celltk/core/operation.py
@@ -1089,6 +1089,7 @@ class BaseExtractor(Operation):
                 return
 
             # Get the data and group with the key
+            propagated = False
             arrs = [array[tuple(k)] for k in keys]
             arr_groups = itertools.permutations(zip(keys, arrs))
             func = getattr(np, func)
@@ -1113,8 +1114,9 @@ class BaseExtractor(Operation):
                         raise ValueError(e)
 
                 # Propagate results to other keys
-                if prop:
+                if prop and not propagated:
                     array.propagate_values(tuple(save_key), prop_to=prop)
+                    propagated = True
                 # If not including inverses, skip all remaining
                 if not incl:
                     break

--- a/celltk/core/pipeline.py
+++ b/celltk/core/pipeline.py
@@ -434,11 +434,18 @@ class Pipeline():
                          f'{im_type} in {folder}.')
 
         # Function to check if img should be loaded
-        def _confirm_im_match(im: str, match_str: str, path: str) -> bool:
+        def _confirm_im_match(im: str,
+                              match_str: str,
+                              path: str,
+                              im_type: str) -> bool:
             name = True if match_str is None else match_str in im
-            ext = self.file_extension in im.split('.')[-1]
-            ext2 = 'hdf5' in im.split('.')[-1]
-            ext = ext or ext2
+
+            # Extension has to be checked based on im_type
+            if im_type == 'array':
+                ext = 'hdf5' in im.split('.')[-1]
+            else:
+                ext = self.file_extension in im.split('.')[-1]
+
             fil = os.path.isfile(os.path.join(path, im))
 
             return name * ext * fil
@@ -449,13 +456,13 @@ class Pipeline():
             if lvl == 0:
                 # Check for images that match in first folder
                 im_names = [os.path.join(pth, f) for f in sorted(files)
-                            if _confirm_im_match(f, match_str, pth)]
+                            if _confirm_im_match(f, match_str, pth, im_type)]
 
             elif pth.split('/')[-1] == match_str:
                 # Check for images if in dir that matches
                 for st in (match_str, im_type, None):
                     im_names = [os.path.join(pth, f) for f in sorted(files)
-                                if _confirm_im_match(f, st, pth)]
+                                if _confirm_im_match(f, st, pth, im_type)]
                     if im_names: break
 
             if im_names: break

--- a/celltk/utils/operation_utils.py
+++ b/celltk/utils/operation_utils.py
@@ -423,25 +423,24 @@ def get_cell_index(cell_id: int,
                    position_array: np.ndarray = None
                    ) -> int:
     """Returns the index of the centroid of a specific cell."""
-    cell_index = np.where(label_array == cell_id)[0]
-    if len(np.unique(cell_index)) > 1:
-        # Greater than one instance found
-        if position_id:
-            assert position_array is not None
-            # Get only the index corresponding to the position_id
-            mask = position_array == position_id
-            cell_index = np.where(
-                np.logical_and(label_array == cell_id, mask)
-            )[0]
-            cell_index = cell_index[0]
-        else:
-            warnings.warn('Found more than one matching cell. Using '
-                          f'first instance found at {cell_index[0]}.')
-            cell_index = cell_index[0]
+    if position_id:
+        assert position_array is not None
+        mask = position_array == position_id
     else:
-        cell_index = cell_index[0]
+        mask = np.ones(label_array.shape).astype(bool)
 
-    return int(cell_index)
+    cell_index = np.where(
+        np.logical_and(label_array == cell_id, mask)
+    )[0]
+
+    if len(cell_index) == 0:
+        warnings.warn(f'Cell {cell_id} not found.', UserWarning)
+        return
+    elif len(np.unique(cell_index)) > 1:
+        warnings.warn('Found more than one matching cell. Using '
+                      f'first instance found at {cell_index[0]}.')
+
+    return int(cell_index[0])
 
 
 def sliding_window_generator(arr: np.ndarray, overlap: int = 0) -> Generator:

--- a/celltk/utils/operation_utils.py
+++ b/celltk/utils/operation_utils.py
@@ -423,7 +423,7 @@ def get_cell_index(cell_id: int,
                    position_array: np.ndarray = None
                    ) -> int:
     """Returns the index of the centroid of a specific cell."""
-    if position_id:
+    if position_id is not None:
         assert position_array is not None
         mask = position_array == position_id
     else:

--- a/celltk/utils/peak_utils.py
+++ b/celltk/utils/peak_utils.py
@@ -469,6 +469,8 @@ class PeakHelper:
         for l in np.unique(label[label > 0]):
             out.append(integrate.simps(trace[label == l]))
 
+        return out
+
     @staticmethod
     def _linearity(trace: np.ndarray,
                    label: np.ndarray

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -734,7 +734,7 @@ class PlotHelper:
                     error_x = None
                     error_y = self._default_error_bar_layout.copy()
                     error_y.update({'type': 'data'})
-                    if err_arr.ndim == 1:
+                    if err_arr.ndim in (0, 1):
                         # Assume symmetric
                         error_y.update({'array': err_arr, 'symmetric': True})
                     elif err_arr.ndim == 2:
@@ -751,7 +751,7 @@ class PlotHelper:
                     error_y = None
                     error_x = self._default_error_bar_layout.copy()
                     error_x.update({'type': 'data'})
-                    if err_arr.ndim == 1:
+                    if err_arr.ndim in (0, 1):
                         # Assume symmetric
                         error_x.update({'array': err_arr, 'symmetric': True})
                     elif err_arr.ndim == 2:

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -613,6 +613,7 @@ class PlotHelper:
                  err_estimator: Union[Callable, str, functools.partial] = None,
                  ax_labels: Collection[str] = None,
                  colors: Union[str, Collection[str]] = None,
+                 alpha: float = 1.0,
                  orientation: str = 'v',
                  barmode: str = 'group',
                  add_cell_numbers: bool = True,
@@ -655,6 +656,7 @@ class PlotHelper:
             in seaborn/matplotlib, then in Plotly to find the color map. If
             not provided, the color map will be glasbey. Can also be list
             of named CSS colors or hexadecimal or RGBA strings.
+        :param alpha: Opacity of the marker fill colors.
         :param ax_labels: Labels for the categorical axis.
         :param orientation: Orientation of the bar plot.
         :param barmode: Keyword argument describing how to group the bars.
@@ -693,7 +695,7 @@ class PlotHelper:
         assert len(figsize) == 2
 
         # Convert any inputs that need converting
-        colors = self._build_colormap(colors, len(arrays))
+        colors = self._build_colormap(colors, len(arrays), alpha)
         if estimator: estimator = self._build_estimator_func(estimator)
         if err_estimator: err_estimator = self._build_estimator_func(err_estimator)
         bar_kwargs = {k: v for k, v in kwargs.items()

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -227,6 +227,7 @@ class PlotHelper:
                   colors: Union[str, Collection[str]] = None,
                   alpha: float = 1.0,
                   time: Union[Collection[np.ndarray], np.ndarray] = None,
+                  add_cell_numbers: bool = True,
                   legend: bool = True,
                   figure: Union[go.Figure, go.FigureWidget] = None,
                   figsize: Tuple[int] = (None, None),
@@ -273,11 +274,13 @@ class PlotHelper:
         :param alpha: Opacity of the line colors.
         :param time: Time axis for the plot. Must be the same size as the
             second dimension of arrays.
+        :param add_cell_numbers: If True, adds the number of cells to each key
+            in keys.
         :param legend: If False, no legend is made on the plot.
         :param figure: If a go.Figure object is given, will be used to make
             the plot instead of a blank figure.
-        :param figsize: Height and width of the plot in pixels. Must be a tuple of
-            length two. To leave height or width unchanged, set as None.
+        :param figsize: Height and width of the plot in pixels. Must be a tuple
+            of length two. To leave height or width unchanged, set as None.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -324,7 +327,8 @@ class PlotHelper:
             # Get the key
             if not key:
                 key = f'line_{idx}'
-            key += f' | n={arr.shape[0]}'
+            if add_cell_numbers and arr is not None:
+                key += f' | n={arr.shape[0]}'
 
             # err_estimator is used to set the bounds for the shaded region
             if err_estimator:
@@ -414,6 +418,7 @@ class PlotHelper:
                      colors: Union[str, Collection[str]] = None,
                      alpha: float = 1.0,
                      symbols: Union[str, Collection[str]] = None,
+                     add_cell_numbers: bool = True,
                      legend: bool = True,
                      figure: Union[go.Figure, go.FigureWidget] = None,
                      figsize: Tuple[int] = (None, None),
@@ -461,11 +466,13 @@ class PlotHelper:
             not provided, the color map will be glasbey. Can also be list
             of named CSS colors or hexadecimal or RGBA strings.
         :param alpha: Opacity of the marker fill colors.
+        :param add_cell_numbers: If True, adds the number of cells to each key
+            in keys.
         :param legend: If False, no legend is made on the plot.
         :param figure: If a go.Figure object is given, will be used to make
             the plot instead of a blank figure.
-        :param figsize: Height and width of the plot in pixels. Must be a tuple of
-            length two. To leave height or width unchanged, set as None.
+        :param figsize: Height and width of the plot in pixels. Must be a tuple
+            of length two. To leave height or width unchanged, set as None.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -529,8 +536,9 @@ class PlotHelper:
             # Get the key
             if not key:
                 key = f'group_{idx}'
-            n = yarr.shape[0] if yarr is not None else xarr.shape[0]
-            key += f' | n={n}'
+            if add_cell_numbers and (yarr is not None or xarr is not None):
+                n = yarr.shape[0] if yarr is not None else xarr.shape[0]
+                key += f' | n={n}'
 
             # err_estimator is used to set error bars
             if err_estimator:
@@ -607,6 +615,7 @@ class PlotHelper:
                  colors: Union[str, Collection[str]] = None,
                  orientation: str = 'v',
                  barmode: str = 'group',
+                 add_cell_numbers: bool = True,
                  legend: bool = True,
                  figure: Union[go.Figure, go.FigureWidget] = None,
                  figsize: Tuple[int] = (None, None),
@@ -650,11 +659,13 @@ class PlotHelper:
         :param orientation: Orientation of the bar plot.
         :param barmode: Keyword argument describing how to group the bars.
             Options are 'group', 'overlay', 'relative', and 'stack'.
+        :param add_cell_numbers: If True, adds the number of cells to each key
+            in keys.
         :param legend: If False, no legend is made on the plot.
         :param figure: If a go.Figure object is given, will be used to make
             the plot instead of a blank figure.
-        :param figsize: Height and width of the plot in pixels. Must be a tuple of
-            length two. To leave height or width unchanged, set as None.
+        :param figsize: Height and width of the plot in pixels. Must be a tuple
+            of length two. To leave height or width unchanged, set as None.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -698,7 +709,8 @@ class PlotHelper:
             # Get the key
             if not key:
                 key = f'bar_{idx}'
-            key += f' | n={arr.shape[0]}'
+            if add_cell_numbers and arr is not None:
+                key += f' | n={arr.shape[0]}'
 
             # err_estimator is used to calculate errorbars
             if err_estimator:
@@ -787,6 +799,7 @@ class PlotHelper:
                        alpha: float = 1.0,
                        orientation: str = 'v',
                        barmode: str = 'group',
+                       add_cell_numbers: bool = True,
                        legend: bool = True,
                        figure: Union[go.Figure, go.FigureWidget] = None,
                        figsize: Tuple[int] = (None, None),
@@ -842,11 +855,13 @@ class PlotHelper:
         :param orientation: Orientation of the bar plot.
         :param barmode: Keyword argument describing how to group the bars.
             Options are 'group', 'overlay', 'stack', and 'relative'.
+        :param add_cell_numbers: If True, adds the number of cells to each key
+            in keys.
         :param legend: If False, no legend is made on the plot.
         :param figure: If a go.Figure object is given, will be used to make
             the plot instead of a blank figure.
-        :param figsize: Height and width of the plot in pixels. Must be a tuple of
-            length two. To leave height or width unchanged, set as None.
+        :param figsize: Height and width of the plot in pixels. Must be a tuple
+            of length two. To leave height or width unchanged, set as None.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -885,8 +900,9 @@ class PlotHelper:
         for idx, (arr, key) in enumerate(itertools.zip_longest(arrays, keys)):
             # Get the key
             if not key:
-                key = f'bar_{idx}'
-            key += f' | n={arr.shape[0]}'
+                key = f'dist_{idx}'
+            if add_cell_numbers and arr is not None:
+                key += f' | n={arr.shape[0]}'
 
             if orientation in ('v', 'vertical'):
                 y = None
@@ -948,6 +964,7 @@ class PlotHelper:
                     show_mean: bool = False,
                     spanmode: str = 'soft',
                     side: str = None,
+                    add_cell_numbers: bool = True,
                     legend: bool = True,
                     figure: Union[go.Figure, go.FigureWidget] = None,
                     figsize: Tuple[int] = (None, None),
@@ -996,11 +1013,13 @@ class PlotHelper:
         :param side: Side to plot the distribution. By default, the
             distribution is plotted on both sides, but can be 'positive'
             or 'negative' to plot on only one side.
+        :param add_cell_numbers: If True, adds the number of cells to each key
+            in keys.
         :param legend: If False, no legend is made on the plot.
         :param figure: If a go.Figure object is given, will be used to make
             the plot instead of a blank figure.
-        :param figsize: Height and width of the plot in pixels. Must be a tuple of
-            length two. To leave height or width unchanged, set as None.
+        :param figsize: Height and width of the plot in pixels. Must be a tuple
+            of length two. To leave height or width unchanged, set as None.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -1059,7 +1078,8 @@ class PlotHelper:
             # Get the key
             if not key:
                 key = f'dist_{idx}'
-            key += f' | n={arr.shape[0]}'
+            if add_cell_numbers and arr is not None:
+                key += f' | n={arr.shape[0]}'
 
             # Set the data key based on orientation
             if orientation in ('v', 'vertical'):
@@ -1131,6 +1151,7 @@ class PlotHelper:
                        show_box: bool = False,
                        show_points: Union[str, bool] = False,
                        show_mean: bool = True,
+                       add_cell_numbers: bool = True,
                        legend: bool = True,
                        figure: Union[go.Figure, go.FigureWidget] = None,
                        figsize: Tuple[int] = (None, None),
@@ -1167,11 +1188,13 @@ class PlotHelper:
         :param side: Side to plot the distribution. By default, the
             distribution is plotted on both sides, but can be 'positive'
             or 'negative' to plot on only one side.
+        :param add_cell_numbers: If True, adds the number of cells to each key
+            in keys.
         :param legend: If False, no legend is made on the plot.
         :param figure: If a go.Figure object is given, will be used to make
             the plot instead of a blank figure.
-        :param figsize: Height and width of the plot in pixels. Must be a tuple of
-            length two. To leave height or width unchanged, set as None.
+        :param figsize: Height and width of the plot in pixels. Must be a tuple
+            of length two. To leave height or width unchanged, set as None.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -1196,6 +1219,7 @@ class PlotHelper:
                                spanmode=spanmode, legend=legend,
                                show_box=show_box, show_points=show_points,
                                show_mean=show_mean, figure=figure, widget=widget,
+                               add_cell_numbers=add_cell_numbers,
                                side='positive', orientation='h', **kwargs)
 
         # Some settings for making a ridgeline out of the violin plot
@@ -1251,8 +1275,8 @@ class PlotHelper:
         :param reverse: If True, the color mapping is reversed.
         :param figure: If a go.Figure object is given, will be used to make
             the plot instead of a blank figure.
-        :param figsize: Height and width of the plot in pixels. Must be a tuple of
-            length two. To leave height or width unchanged, set as None.
+        :param figsize: Height and width of the plot in pixels. Must be a tuple
+            of length two. To leave height or width unchanged, set as None.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -1358,8 +1382,8 @@ class PlotHelper:
             bin AREAS equals 1).
         :param figure: If a go.Figure object is given, will be used to make
             the plot instead of a blank figure.
-        :param figsize: Height and width of the plot in pixels. Must be a tuple of
-            length two. To leave height or width unchanged, set as None.
+        :param figsize: Height and width of the plot in pixels. Must be a tuple
+            of length two. To leave height or width unchanged, set as None.
         :param title: Title to add to the plot.
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -1472,8 +1496,8 @@ class PlotHelper:
             bin AREAS equals 1).
         :param figure: If a go.Figure object is given, will be used to make
             the plot instead of a blank figure.
-        :param figsize: Height and width of the plot in pixels. Must be a tuple of
-            length two. To leave height or width unchanged, set as None.
+        :param figsize: Height and width of the plot in pixels. Must be a tuple
+            of length two. To leave height or width unchanged, set as None.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis

--- a/tests/plot_tests.py
+++ b/tests/plot_tests.py
@@ -1,0 +1,73 @@
+import sys
+import os
+
+import numpy as np
+import plotly.graph_objects as go
+
+# Correct import paths
+cwd = os.path.dirname(os.path.realpath(__file__))
+par = os.path.dirname(cwd)
+sys.path.insert(0, par)
+
+import celltk
+from celltk.utils.plot_utils import PlotHelper
+
+
+class TestPlots:
+    _exp_array_path = os.path.join(par, 'examples', 'example_experiment.hdf5')
+    _keys = ['control_20K', 'ifny_10_20K']
+
+    def test_each_plot(self) -> None:
+        """"""
+        # Load array and get np array data
+        self.ph = PlotHelper()
+        arr = celltk.ExperimentArray.load(self._exp_array_path)
+
+        # Lists of 2D arrays for some plots
+        data = arr[self._keys]['nuc', 'fitc', 'median_intensity']
+        data2 = arr[self._keys]['nuc', 'cfp', 'median_intensity']
+
+        # Lists of 1D arrays for the rest
+        datum = [d[:, 0] for d in data]
+        datum2 = [d[:, 0] for d in data2]
+
+        # Go through the list of plots and generate each one
+        # Randomly testing some options throughout
+        bar = self.ph.bar_plot(datum, estimator=np.nanmean)
+        assert isinstance(bar, go.Figure)
+
+        contour = self.ph.contour2d_plot(datum[0], datum2[0], robust_z=True)
+        assert isinstance(contour, go.Figure)
+
+        heatmap = self.ph.heatmap2d_plot(datum[0], datum2[0], widget=True)
+        assert isinstance(heatmap, go.FigureWidget)
+
+        heatmap = self.ph.heatmap_plot(data[0], robust_z=True)
+        assert isinstance(heatmap, go.Figure)
+
+        histogram = self.ph.histogram_plot(datum, histnorm='probability')
+        assert isinstance(histogram, go.Figure)
+
+        line = self.ph.line_plot(data, estimator=np.nanmean,
+                                 err_estimator=np.nanstd)
+        assert isinstance(line, go.Figure)
+
+        ridge = self.ph.ridgeline_plot(datum)
+        assert isinstance(ridge, go.Figure)
+
+        scatter = self.ph.scatter_plot(datum, datum2)
+        assert isinstance(scatter, go.Figure)
+
+    def test_trace_color(self) -> None:
+        # Load array and get np array data
+        self.ph = PlotHelper()
+        arr = celltk.ExperimentArray.load(self._exp_array_path)
+
+        data = arr['control_20K']['nuc', 'fitc', 'median_intensity']
+        color = arr['control_20K']['nuc', 'fitc', 'peak_prob']
+        thres = 0.5
+        colors = ['black', 'red']
+
+        gen = self.ph.trace_color_plot(data, color, thres, colors)
+        for f in gen:
+            assert isinstance(f, go.Figure)


### PR DESCRIPTION
This PR introduces a number of small bug fixes. Most of the changes are on the back end.

**Improved**
- `expand_to_cytoring` can now accept a threshold or a mask, beyond which the labels will not be expanded.
- `alpha` option is added to bar plots.
- Added basic unit tests for plotting.

**Fixed**
- Fixed a bug in plots where cell numbers could not be added to the key and therefore the plot wouldn't be made. Dirty fix, but now adding cell numbers is now optional.
- Fixed a bug in `get_cell_index` where it would not find cells with `position_id` 0.
- Fixed a bug where AUC values were not returned from `PeakHelper`.
- Fixed a bug where error bars would not be added to bar plots. The issue was having too strict a check for the dimensions of the error bar array.
- Fixed a bug where `Pipeline` would try to load an `hdf5` file as in image in some cases. `Pipeline._get_image_paths` now explicitly checks file extensions and doesn't return found `hdf5` files unless the expected type is `array`.
- Fixed a bug where time was not properly saved  or loaded to/from file in `ExperimentArrays`. 
- Fixed a bug where inverses of derived metrics would overwrite the original values.
