### PR TITLE
V042

### DIFF
--- a/celltk/process.py
+++ b/celltk/process.py
@@ -104,6 +104,30 @@ class Process(BaseProcess):
 
         return flat_outputs
 
+    @ImageHelper(by_frame=False, as_tuple=True)
+    def crop_to_area(self,
+                     image: Image[Optional] = tuple([]),
+                     mask: Mask[Optional] = tuple([]),
+                     crop_factor: float = 0.6
+                     ) -> Stack:
+        """
+        """
+        flat_inputs = image + mask
+        sizes = [s.shape for s in flat_inputs]
+        assert len(tuple(groupby(sizes))) == 1, 'Stacks must be same shape'
+        _, x, y = sizes[0]
+
+        axis_factor = crop_factor ** 0.5
+        x_amount = np.floor((axis_factor * x) / 2)
+        y_amount = np.floor((axis_factor * y) / 2)
+        crop_vals = (int(x_amount), int(y_amount))
+
+        out = [crop_array(f, crop_vals) for f in flat_inputs]
+        out = [crop_array(f, (-1 * crop_vals[0], -1 * crop_vals[1]))
+               for f in out]
+
+        return out
+
     @ImageHelper(by_frame=True, as_tuple=True)
     def tile_images(self,
                     image: Image[Optional] = tuple([]),

--- a/celltk/utils/estimator_utils.py
+++ b/celltk/utils/estimator_utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Tuple, Callable
 
 import numpy as np
 import scipy.stats as stats
@@ -28,7 +28,8 @@ def confidence_interval(arr: np.ndarray,
 
 def get_bootstrap_population(arr: np.ndarray,
                              boot_reps: int = 1000,
-                             seed: int = 69420
+                             seed: int = 69420,
+                             function: Callable = np.nanmean
                              ) -> np.ndarray:
     """
 
@@ -42,7 +43,7 @@ def get_bootstrap_population(arr: np.ndarray,
     _rng = np.random.default_rng(seed)
     boot_arrs = [_rng.choice(arr, size=arr.shape[0], replace=True)
                  for _ in range(boot_reps)]
-    arr = np.vstack([np.nanmean(b, 0) for b in boot_arrs])
+    arr = np.vstack([function(b, 0) for b in boot_arrs])
 
     return arr
 
@@ -51,7 +52,8 @@ def bootstrap_estimator(arr: np.ndarray,
                         reps: int = 1000,
                         ci: float = 0.95,
                         ax: int = 0,
-                        ignore_nans: bool = True
+                        ignore_nans: bool = True,
+                        function: Callable = np.nanmean
                         ) -> Tuple[np.ndarray]:
     """Uses bootstrap resampling to estimate a confidence interval.
     """
@@ -59,7 +61,7 @@ def bootstrap_estimator(arr: np.ndarray,
     ci *= 100
 
     # Sample the boostrap population
-    boot = get_bootstrap_population(arr, reps)
+    boot = get_bootstrap_population(arr, reps, function=function)
 
     if ignore_nans:
         func = np.nanpercentile

--- a/celltk/utils/estimator_utils.py
+++ b/celltk/utils/estimator_utils.py
@@ -43,7 +43,7 @@ def get_bootstrap_population(arr: np.ndarray,
     _rng = np.random.default_rng(seed)
     boot_arrs = [_rng.choice(arr, size=arr.shape[0], replace=True)
                  for _ in range(boot_reps)]
-    arr = np.vstack([function(b, 0) for b in boot_arrs])
+    arr = np.vstack([function(b, axis=0) for b in boot_arrs])
 
     return arr
 
@@ -51,7 +51,7 @@ def get_bootstrap_population(arr: np.ndarray,
 def bootstrap_estimator(arr: np.ndarray,
                         reps: int = 1000,
                         ci: float = 0.95,
-                        ax: int = 0,
+                        axis: int = 0,
                         ignore_nans: bool = True,
                         function: Callable = np.nanmean
                         ) -> Tuple[np.ndarray]:
@@ -69,28 +69,28 @@ def bootstrap_estimator(arr: np.ndarray,
         func = np.percentile
 
     # Calculate bounds
-    low_end = func(boot, 50. - ci / 2., axis=ax, keepdims=True)
-    hi_end = func(boot, 50. + ci / 2., axis=ax, keepdims=True)
+    low_end = func(boot, 50. - ci / 2., axis=axis, keepdims=True)
+    hi_end = func(boot, 50. + ci / 2., axis=axis, keepdims=True)
 
     return np.vstack((hi_end, low_end))
 
 
 def fraction_of_total(arr: np.ndarray,
                       ignore_nans: bool = True,
-                      ax: int = 0
+                      axis: int = 0
                       ) -> np.ndarray:
     """Returns the fraction of entries that have non-zero values.
     """
     if ignore_nans:
         return np.count_nonzero(arr[~np.isnan(arr)],
-                                axis=ax, keepdims=True) / arr.shape[ax]
+                                axis=axis, keepdims=True) / arr.shape[axis]
     else:
-        return np.count_nonzero(arr, axis=ax, keepdims=True) / arr.shape[ax]
+        return np.count_nonzero(arr, axis=axis, keepdims=True) / arr.shape[axis]
 
 
 def wilson_score(arr: np.ndarray,
                  ci: float = 0.95,
-                 ax: int = 0
+                 axis: int = 0
                  ) -> np.ndarray:
     """Calculates the Wilson score for a binomial distribution.
     """
@@ -98,10 +98,10 @@ def wilson_score(arr: np.ndarray,
     z = stats.norm.ppf(1 - (1 - ci) / 2)
 
     # Get proportion of population that is positive
-    prob = np.squeeze(fraction_of_total(arr, ax=ax))
+    prob = np.squeeze(fraction_of_total(arr, axis=axis))
 
     # Get cell counts for each column
-    n = (~np.isnan(arr)).sum(ax)
+    n = (~np.isnan(arr)).sum(axis)
 
     # Calculate the wilson score
     denom = 1 + z ** 2 / n
@@ -116,15 +116,15 @@ def wilson_score(arr: np.ndarray,
 
 def normal_approx(arr: np.ndarray,
                   ci: float = 0.95,
-                  ax: int = 0
+                  axis: int = 0
                   ) -> np.ndarray:
     """Calculates the normal error for a binomial distribution."""
     # Do two-tailed by default, so divide by 2
     z = stats.norm.ppf(1 - (1 - ci) / 2)
 
     # Get proportion of population that is positive
-    prob = np.squeeze(fraction_of_total(arr, ax=ax))
+    prob = np.squeeze(fraction_of_total(arr, axis=axis))
     # Get cell counts
-    n = (~np.isnan(arr)).sum(ax)
+    n = (~np.isnan(arr)).sum(axis)
 
     return z * np.sqrt((prob * (1 - prob)) / n)

--- a/celltk/utils/operation_utils.py
+++ b/celltk/utils/operation_utils.py
@@ -655,19 +655,12 @@ def shift_array(array: np.ndarray,
 
 def crop_array(array: np.ndarray,
                crop_vals: Tuple[int] = None,
-               crop_area: float = 0.6
                ) -> np.ndarray:
     """Crops an image to the specified dimensions.
 
     TODO:
-        - crop_vals is None - use crop area to calc crop vals
         - There must be a much neater way to write this function
-        - Incorporate crop_area
     """
-    if crop_vals is None:
-        # TODO: calculate crop coordinates for area
-        pass
-
     y, x = crop_vals
 
     if y == 0 and x == 0:

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -37,7 +37,7 @@ class PlotHelper:
         'ticklen': 7,
         'ticks': 'outside',
         'tickwidth': 2,
-        'title': dict(font=dict(color='#242424', size=24)),
+        'title': dict(font=dict(color='#242424', size=24, family=_font_families)),
         'zeroline': False,
     }
     _no_line_axis = _default_axis_layout.copy()

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -140,6 +140,7 @@ class PlotHelper:
                              tick_size: float = None,
                              axis_label_size: float = None,
                              axis_type: str = 'default',
+                             margin: str = 'auto',
                              **kwargs
                              ) -> go.Figure:
         """
@@ -157,7 +158,14 @@ class PlotHelper:
         else:
             raise ValueError(f'Did not understand axis type {axis_type}.')
 
-        figure_layout = {'template': deepcopy(self._template)}
+        figure_layout = {'template': self._template}
+
+        # Apply changes to margins
+        if isinstance(margin, (float, int)):
+            m = int(margin)
+            figure_layout.update({'margin': dict(l=m, r=m, b=m, t=m)})
+        elif margin in (False, 'zero', 'tight'):
+            figure_layout.update({'margin': dict(l=0, r=0, t=0, b=0)})
 
         # Updates only made if not None, preserves old values
         if legend is not None:
@@ -371,6 +379,7 @@ class PlotHelper:
                   legend: bool = True,
                   figure: Union[go.Figure, go.FigureWidget] = None,
                   figsize: Tuple[int] = (None, None),
+                  margin: str = 'auto',
                   title: str = None,
                   x_label: str = None,
                   y_label: str = None,
@@ -424,6 +433,9 @@ class PlotHelper:
             the plot instead of a blank figure.
         :param figsize: Height and width of the plot in pixels. Must be a tuple
             of length two. To leave height or width unchanged, set as None.
+        :param margin: Set the size of the margins. If 'auto', all margins
+            are set to defualt values. If 'zero' or 'tight', margins are
+            removed. If a number is given, sets all margins to that number.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -550,7 +562,7 @@ class PlotHelper:
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         legend, tick_size, axis_label_size,
-                                        axis_type='default')
+                                        axis_type='default', margin=margin)
 
         return fig
 
@@ -569,6 +581,7 @@ class PlotHelper:
                      legend: bool = True,
                      figure: Union[go.Figure, go.FigureWidget] = None,
                      figsize: Tuple[int] = (None, None),
+                     margin: str = 'auto',
                      title: str = None,
                      x_label: str = None,
                      y_label: str = None,
@@ -625,6 +638,9 @@ class PlotHelper:
             the plot instead of a blank figure.
         :param figsize: Height and width of the plot in pixels. Must be a tuple
             of length two. To leave height or width unchanged, set as None.
+        :param margin: Set the size of the margins. If 'auto', all margins
+            are set to defualt values. If 'zero' or 'tight', margins are
+            removed. If a number is given, sets all margins to that number.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -756,7 +772,7 @@ class PlotHelper:
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         legend, tick_size, axis_label_size,
-                                        axis_type='default')
+                                        axis_type='default', margin=margin)
 
         return fig
 
@@ -774,6 +790,7 @@ class PlotHelper:
                  legend: bool = True,
                  figure: Union[go.Figure, go.FigureWidget] = None,
                  figsize: Tuple[int] = (None, None),
+                 margin: str = 'auto',
                  title: str = None,
                  x_label: str = None,
                  y_label: str = None,
@@ -824,6 +841,9 @@ class PlotHelper:
             the plot instead of a blank figure.
         :param figsize: Height and width of the plot in pixels. Must be a tuple
             of length two. To leave height or width unchanged, set as None.
+        :param margin: Set the size of the margins. If 'auto', all margins
+            are set to defualt values. If 'zero' or 'tight', margins are
+            removed. If a number is given, sets all margins to that number.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -933,7 +953,7 @@ class PlotHelper:
                                         x_label, y_label, x_limit, y_limit,
                                         legend, tick_size, axis_label_size,
                                         axis_type='default',
-                                        barmode=barmode)
+                                        barmode=barmode, margin=margin)
         fig.update_traces(**kwargs)
 
         return fig
@@ -962,6 +982,7 @@ class PlotHelper:
                        legend: bool = True,
                        figure: Union[go.Figure, go.FigureWidget] = None,
                        figsize: Tuple[int] = (None, None),
+                       margin: str = 'auto',
                        title: str = None,
                        x_label: str = None,
                        y_label: str = None,
@@ -1040,6 +1061,9 @@ class PlotHelper:
             the plot instead of a blank figure.
         :param figsize: Height and width of the plot in pixels. Must be a tuple
             of length two. To leave height or width unchanged, set as None.
+        :param margin: Set the size of the margins. If 'auto', all margins
+            are set to defualt values. If 'zero' or 'tight', margins are
+            removed. If a number is given, sets all margins to that number.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -1175,7 +1199,7 @@ class PlotHelper:
                                         x_label, y_label, x_limit, y_limit,
                                         legend, tick_size, axis_label_size,
                                         axis_type='default',
-                                        barmode=barmode,
+                                        barmode=barmode, margin=margin,
                                         bargap=bargap, bargroupgap=bargroupgap)
 
         return fig
@@ -1198,6 +1222,7 @@ class PlotHelper:
                     legend: bool = True,
                     figure: Union[go.Figure, go.FigureWidget] = None,
                     figsize: Tuple[int] = (None, None),
+                    margin: str = 'auto',
                     title: str = None,
                     x_label: str = None,
                     y_label: str = None,
@@ -1239,6 +1264,7 @@ class PlotHelper:
             violin plot.
         :param show_points: If True, individual data points are overlaid over
             the violin plot.
+        :param show_mean: If True, dashed line is plotted at the mean value.
         :param spanmode: Determines how far the tails of the violin plot are
             extended. If 'hard', the plot spans as far as the data. If 'soft',
             the tails are extended.
@@ -1252,6 +1278,9 @@ class PlotHelper:
             the plot instead of a blank figure.
         :param figsize: Height and width of the plot in pixels. Must be a tuple
             of length two. To leave height or width unchanged, set as None.
+        :param margin: Set the size of the margins. If 'auto', all margins
+            are set to defualt values. If 'zero' or 'tight', margins are
+            removed. If a number is given, sets all margins to that number.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -1365,7 +1394,7 @@ class PlotHelper:
                                         x_label, y_label, x_limit, y_limit,
                                         legend, tick_size, axis_label_size,
                                         axis_type='default',
-                                        violinmode=violinmode)
+                                        violinmode=violinmode, margin=margin)
         fig.update_traces(**kwargs)
 
         return fig
@@ -1383,6 +1412,7 @@ class PlotHelper:
                        legend: bool = True,
                        figure: Union[go.Figure, go.FigureWidget] = None,
                        figsize: Tuple[int] = (None, None),
+                       margin: str = 'auto',
                        title: str = None,
                        x_label: str = None,
                        y_label: str = None,
@@ -1425,6 +1455,9 @@ class PlotHelper:
             the plot instead of a blank figure.
         :param figsize: Height and width of the plot in pixels. Must be a tuple
             of length two. To leave height or width unchanged, set as None.
+        :param margin: Set the size of the margins. If 'auto', all margins
+            are set to defualt values. If 'zero' or 'tight', margins are
+            removed. If a number is given, sets all margins to that number.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -1460,7 +1493,7 @@ class PlotHelper:
                                         legend, tick_size, axis_label_size,
                                         axis_type='default',
                                         xaxis_showgrid=False,
-                                        xaxis_zeroline=False)
+                                        xaxis_zeroline=False, margin=margin)
         fig.update_traces(width=overlap)
 
         return fig
@@ -1476,6 +1509,7 @@ class PlotHelper:
                      sort: str = None,
                      figure: Union[go.Figure, go.FigureWidget] = None,
                      figsize: Tuple[int] = (None, None),
+                     margin: str = 'auto',
                      title: str = None,
                      x_label: str = None,
                      y_label: str = None,
@@ -1516,6 +1550,9 @@ class PlotHelper:
             the plot instead of a blank figure.
         :param figsize: Height and width of the plot in pixels. Must be a tuple
             of length two. To leave height or width unchanged, set as None.
+        :param margin: Set the size of the margins. If 'auto', all margins
+            are set to defualt values. If 'zero' or 'tight', margins are
+            removed. If a number is given, sets all margins to that number.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -1568,7 +1605,7 @@ class PlotHelper:
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         tick_size, axis_label_size,
-                                        axis_type='noline')
+                                        axis_type='noline', margin=margin)
 
         return fig
 
@@ -1586,6 +1623,7 @@ class PlotHelper:
                        histnorm: str = "",
                        figure: Union[go.Figure, go.FigureWidget] = None,
                        figsize: Tuple[int] = (None, None),
+                       margin: str = 'auto',
                        title: str = None,
                        x_label: str = None,
                        y_label: str = None,
@@ -1641,6 +1679,9 @@ class PlotHelper:
             the plot instead of a blank figure.
         :param figsize: Height and width of the plot in pixels. Must be a tuple
             of length two. To leave height or width unchanged, set as None.
+        :param margin: Set the size of the margins. If 'auto', all margins
+            are set to defualt values. If 'zero' or 'tight', margins are
+            removed. If a number is given, sets all margins to that number.
         :param title: Title to add to the plot.
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -1694,7 +1735,7 @@ class PlotHelper:
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         tick_size, axis_label_size,
-                                        axis_type='noline')
+                                        axis_type='noline', margin=margin)
 
         return fig
 
@@ -1712,6 +1753,7 @@ class PlotHelper:
                        histnorm: str = "",
                        figure: Union[go.Figure, go.FigureWidget] = None,
                        figsize: Tuple[int] = (None, None),
+                       margin: str = 'auto',
                        title: str = None,
                        x_label: str = None,
                        y_label: str = None,
@@ -1767,6 +1809,9 @@ class PlotHelper:
             the plot instead of a blank figure.
         :param figsize: Height and width of the plot in pixels. Must be a tuple
             of length two. To leave height or width unchanged, set as None.
+        :param margin: Set the size of the margins. If 'auto', all margins
+            are set to defualt values. If 'zero' or 'tight', margins are
+            removed. If a number is given, sets all margins to that number.
         :param title: Title to add to the plot
         :param x_label: Label of the x-axis
         :param y_label: Label of the y-axis
@@ -1820,7 +1865,7 @@ class PlotHelper:
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         tick_size, axis_label_size,
-                                        axis_type='noline')
+                                        axis_type='noline', margin=margin)
 
         return fig
 

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -524,7 +524,7 @@ class PlotHelper:
                 x = time
             else:
                 raise TypeError('Did not understand time of '
-                                f'type {type(time)}')
+                                f'type {type(time)}.')
 
             lines = []
             _legend = True
@@ -1743,10 +1743,12 @@ class PlotHelper:
                        x_array: np.ndarray,
                        y_array: np.ndarray,
                        colorscale: str = 'viridis',
+                       fill: bool = True,
                        zmin: float = None,
                        zmid: float = None,
                        zmax: float = None,
                        robust_z: bool = False,
+                       width: float = 0.5,
                        xbinsize: float = None,
                        ybinsize: float = None,
                        histfunc: str = 'count',
@@ -1778,6 +1780,8 @@ class PlotHelper:
             "Blackbody", "Bluered", "Blues", "Cividis", "Earth", "Electric",
             "Greens", "Greys", "Hot", "Jet", "Picnic", "Portland", "Rainbow",
             "RdBu", "Reds", "Viridis", "YlGnBu", and "YlOrRd".
+        :param fill: If True, space between contour lines is filled with color,
+            otherwise, only the lines are colored.
         :param zmin: Sets the lower bound of the color domain. If given, zmax
             must also be given.
         :param zmid: Sets the midpoint of the color domain by setting zmin and
@@ -1786,6 +1790,7 @@ class PlotHelper:
             must also be given.
         :param robust_z: If True, uses percentiles to set zmin and zmax instead
             of extremes of the dataset.
+        :param width: Width of the contour lines.
         :param xbinsize: Size of the bins along the x-axis.
         :param ybinsize: Size of the bins along the y-axis.
         :param histfunc: Specifies the binning function used for
@@ -1844,6 +1849,12 @@ class PlotHelper:
             zmax = np.nanpercentile(_arr, 98)
             zmid = None
 
+        if fill:
+            contours = {'coloring': 'fill'}
+        else:
+            contours = {'coloring': 'lines'}
+        line = {'width': width}
+
         # Build the figure and plot the contours
         if figure:
             fig = figure
@@ -1854,6 +1865,7 @@ class PlotHelper:
 
         trace = go.Histogram2dContour(x=x_array, y=y_array,
                                       colorscale=colorscale,
+                                      contours=contours, line=line,
                                       histfunc=histfunc,
                                       histnorm=histnorm,
                                       zmin=zmin, zmid=zmid, zmax=zmax,

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -141,6 +141,8 @@ class PlotHelper:
                              axis_label_size: float = None,
                              axis_type: str = 'default',
                              margin: str = 'auto',
+                             row: int = None,
+                             col: int = None,
                              **kwargs
                              ) -> go.Figure:
         """
@@ -193,8 +195,8 @@ class PlotHelper:
 
         # Apply changes
         figure.update_layout(**figure_layout, **kwargs)
-        figure.update_xaxes(**x_axis_layout)
-        figure.update_yaxes(**y_axis_layout)
+        figure.update_xaxes(**x_axis_layout, row=row, col=col)
+        figure.update_yaxes(**y_axis_layout, row=row, col=col)
 
         return figure
 
@@ -389,6 +391,8 @@ class PlotHelper:
                   axis_label_size: float = None,
                   widget: bool = False,
                   gl: bool = False,
+                  row: int = None,
+                  col: int = None,
                   **kwargs
                   ) -> Union[go.Figure, go.FigureWidget]:
         """
@@ -450,6 +454,14 @@ class PlotHelper:
         :param gl: If True, switches to using a WebGL backend. Much faster for
             large datasets, but some features may not be available. May not
             work in all contexts.
+        :param row: If Figure has multiple subplots, specifies which row
+            to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
+        :param col: If Figure has multiple subplots, specifies which
+            col to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
         :param kwargs: Depending on name, passed to the "line" keyword
             argument of go.Scatter or as keyword arguments for go.Scatter.
             The following kwargs are passed to "line": 'color', 'dash',
@@ -556,13 +568,14 @@ class PlotHelper:
                                 hoverinfo='skip')
                     )
 
-            fig.add_traces(lines)
+            fig.add_traces(lines, rows=row, cols=col)
 
         # Upate the axes and figure layout
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         legend, tick_size, axis_label_size,
-                                        axis_type='default', margin=margin)
+                                        axis_type='default', margin=margin,
+                                        row=row, col=col)
 
         return fig
 
@@ -591,6 +604,8 @@ class PlotHelper:
                      axis_label_size: float = None,
                      widget: bool = False,
                      gl: bool = False,
+                     row: int = None,
+                     col: int = None,
                      **kwargs
                      ) -> Union[go.Figure, go.FigureWidget]:
         """
@@ -655,6 +670,14 @@ class PlotHelper:
         :param gl: If True, switches to using a WebGL backend. Much faster for
             large datasets, but some features may not be available. May not
             work in all contexts.
+        :param row: If Figure has multiple subplots, specifies which row
+            to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
+        :param col: If Figure has multiple subplots, specifies which
+            col to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
         :param kwargs: Depending on name, passed to the "marker" keyword
             argument of go.Scatter or as keyword arguments for go.Scatter.
             The following kwargs are passed to "marker": 'color', 'line',
@@ -766,13 +789,14 @@ class PlotHelper:
                         marker=marker_kwargs, **kwargs)
             )
 
-        fig.add_traces(traces)
+        fig.add_traces(traces, rows=row, cols=col)
 
         # Apply formatting and return
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         legend, tick_size, axis_label_size,
-                                        axis_type='default', margin=margin)
+                                        axis_type='default', margin=margin,
+                                        row=row, col=col)
 
         return fig
 
@@ -799,6 +823,8 @@ class PlotHelper:
                  tick_size: float = None,
                  axis_label_size: float = None,
                  widget: bool = False,
+                 row: int = None,
+                 col: int = None,
                  **kwargs
                  ) -> Union[go.Figure, go.FigureWidget]:
         """Builds a Plotly Figure object plotting bars from the given arrays. Each
@@ -857,6 +883,14 @@ class PlotHelper:
         :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
+        :param row: If Figure has multiple subplots, specifies which row
+            to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
+        :param col: If Figure has multiple subplots, specifies which
+            col to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
         :param kwargs: Depending on name, passed to go.Bar or to
             go.Figure.update_traces(). The following kwargs are passed to
             go.Bar: 'hoverinfo', 'marker', 'width'.
@@ -946,15 +980,16 @@ class PlotHelper:
 
             trace = go.Bar(x=x, y=y, error_x=error_x, error_y=error_y,
                            name=key, **bar_kwargs)
-            fig.add_trace(trace)
+            fig.add_traces(trace, rows=row, cols=col)
 
         # Format plot on the way out
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         legend, tick_size, axis_label_size,
                                         axis_type='default',
-                                        barmode=barmode, margin=margin)
-        fig.update_traces(**kwargs)
+                                        barmode=barmode, margin=margin,
+                                        row=row, col=col)
+        fig.update_traces(**kwargs, row=row, col=col)
 
         return fig
 
@@ -991,6 +1026,8 @@ class PlotHelper:
                        tick_size: float = None,
                        axis_label_size: float = None,
                        widget: bool = False,
+                       row: int = None,
+                       col: int = None,
                        **kwargs
                        ) -> Union[go.Figure, go.FigureWidget]:
         """Builds a Plotly Figure object plotting a histogram of each of the
@@ -1077,6 +1114,14 @@ class PlotHelper:
         :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
+        :param row: If Figure has multiple subplots, specifies which row
+            to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
+        :param col: If Figure has multiple subplots, specifies which
+            col to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
         :param kwargs: Depending on name, kwargs are passed to either
             go.Histogram or the line kwarg of go.Scatter if a kernel density
             estimate is included. The following kwargs are passed to "line":
@@ -1146,7 +1191,7 @@ class PlotHelper:
                                      ybins=dict(size=binsize),
                                      marker=marker_kwargs,
                                      **kwargs)
-                fig.add_trace(trace)
+                fig.add_traces(trace, rows=row, cols=col)
 
             # Estimate and plot KDE
             if include_kde:
@@ -1192,7 +1237,7 @@ class PlotHelper:
                 line = go.Scatter(x=x, y=y,
                                   legendgroup=key, name=key, fill=fill,
                                   mode='lines', line=line_kwargs)
-                fig.add_trace(line)
+                fig.add_traces(line, rows=row, cols=col)
 
         # Format plot on the way out
         fig = self._apply_format_figure(fig, figsize, title,
@@ -1200,7 +1245,8 @@ class PlotHelper:
                                         legend, tick_size, axis_label_size,
                                         axis_type='default',
                                         barmode=barmode, margin=margin,
-                                        bargap=bargap, bargroupgap=bargroupgap)
+                                        bargap=bargap, bargroupgap=bargroupgap,
+                                        row=row, col=col)
 
         return fig
 
@@ -1231,6 +1277,8 @@ class PlotHelper:
                     tick_size: float = None,
                     axis_label_size: float = None,
                     widget: bool = False,
+                    row: int = None,
+                    col: int = None,
                     **kwargs
                     ) -> Union[go.Figure, go.FigureWidget]:
         """
@@ -1294,6 +1342,14 @@ class PlotHelper:
         :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
+        :param row: If Figure has multiple subplots, specifies which row
+            to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
+        :param col: If Figure has multiple subplots, specifies which
+            col to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
         :param kwargs: Depending on name, passed to go.Violin or to
             go.Figure.update_traces(). The following kwargs are passed to
             go.Violin: 'bandwidth', 'fillcolor', 'hoverinfo', 'jitter', 'line',
@@ -1370,7 +1426,7 @@ class PlotHelper:
                               points=show_points, hoverinfo='skip',
                               line=line, meanline=meanline_kw,
                               **violin_kwargs)
-            fig.add_trace(trace)
+            fig.add_traces(trace, rows=row, cols=col)
 
             # Add the other half of the distributions if needed
             if neg_arrays:
@@ -1387,14 +1443,15 @@ class PlotHelper:
                                       points=show_points, hoverinfo='skip',
                                       line=line, meanline=meanline_kw,
                                       **violin_kwargs)
-                fig.add_trace(neg_trace)
+                fig.add_traces(neg_trace, rows=row, cols=col)
 
         # Format plot on the way out
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         legend, tick_size, axis_label_size,
                                         axis_type='default',
-                                        violinmode=violinmode, margin=margin)
+                                        violinmode=violinmode, margin=margin,
+                                        row=row, col=col)
         fig.update_traces(**kwargs)
 
         return fig
@@ -1421,6 +1478,8 @@ class PlotHelper:
                        tick_size: float = None,
                        axis_label_size: float = None,
                        widget: bool = False,
+                       row: int = None,
+                       col: int = None,
                        **kwargs
                        ) -> Union[go.Figure, go.FigureWidget]:
         """
@@ -1471,6 +1530,14 @@ class PlotHelper:
         :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
+        :param row: If Figure has multiple subplots, specifies which row
+            to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
+        :param col: If Figure has multiple subplots, specifies which
+            col to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
         :param kwargs: Depending on name, passed to go.Violin or to
             go.Figure.update_traces(). The following kwargs are passed to
             go.Violin: 'bandwidth', 'fillcolor', 'hoverinfo', 'jitter', 'line',
@@ -1485,7 +1552,8 @@ class PlotHelper:
                                show_box=show_box, show_points=show_points,
                                show_mean=show_mean, figure=figure, widget=widget,
                                add_cell_numbers=add_cell_numbers,
-                               side='positive', orientation='h', **kwargs)
+                               side='positive', orientation='h',
+                               row=row, col=col, **kwargs)
 
         # Some settings for making a ridgeline out of the violin plot
         fig = self._apply_format_figure(fig, figsize, title,
@@ -1493,7 +1561,8 @@ class PlotHelper:
                                         legend, tick_size, axis_label_size,
                                         axis_type='default',
                                         xaxis_showgrid=False,
-                                        xaxis_zeroline=False, margin=margin)
+                                        xaxis_zeroline=False, margin=margin,
+                                        row=row, col=col)
         fig.update_traces(width=overlap)
 
         return fig
@@ -1518,6 +1587,8 @@ class PlotHelper:
                      tick_size: float = None,
                      axis_label_size: float = None,
                      widget: bool = False,
+                     row: int = None,
+                     col: int = None,
                      **kwargs
                      ) -> Union[go.Figure, go.FigureWidget]:
         """
@@ -1566,6 +1637,14 @@ class PlotHelper:
         :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
+        :param row: If Figure has multiple subplots, specifies which row
+            to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
+        :param col: If Figure has multiple subplots, specifies which
+            col to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
         :param kwargs: Passed to go.Heatmap.
 
         :return: Figure object.
@@ -1600,12 +1679,14 @@ class PlotHelper:
         trace = go.Heatmap(z=array, zmin=zmin, zmax=zmax,
                            zmid=zmid, colorscale=colorscale,
                            reversescale=reverse, **kwargs)
-        fig.add_trace(trace)
+        fig.add_traces(trace, rows=row, cols=col)
 
+        # None is for the legend kwarg
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        tick_size, axis_label_size,
-                                        axis_type='noline', margin=margin)
+                                        None, tick_size, axis_label_size,
+                                        axis_type='noline', margin=margin,
+                                        row=row, col=col)
 
         return fig
 
@@ -1632,6 +1713,8 @@ class PlotHelper:
                        tick_size: float = None,
                        axis_label_size: float = None,
                        widget: bool = False,
+                       row: int = None,
+                       col: int = None,
                        **kwargs
                        ) -> Union[go.Figure, go.FigureWidget]:
         """
@@ -1695,6 +1778,14 @@ class PlotHelper:
         :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
+        :param row: If Figure has multiple subplots, specifies which row
+            to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
+        :param col: If Figure has multiple subplots, specifies which
+            col to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
         :param kwargs: Passed to go.Histogram2d.
 
         :return: Figure object
@@ -1730,12 +1821,13 @@ class PlotHelper:
                                xbins=dict(size=xbinsize),
                                ybins=dict(size=ybinsize),
                                **kwargs)
-        fig.add_trace(trace)
+        fig.add_traces(trace, rows=row, cols=col)
 
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         tick_size, axis_label_size,
-                                        axis_type='noline', margin=margin)
+                                        axis_type='noline', margin=margin,
+                                        row=row, col=col)
 
         return fig
 
@@ -1764,6 +1856,8 @@ class PlotHelper:
                        tick_size: float = None,
                        axis_label_size: float = None,
                        widget: bool = False,
+                       row: int = None,
+                       col: int = None,
                        **kwargs
                        ) -> Union[go.Figure, go.FigureWidget]:
         """
@@ -1830,6 +1924,14 @@ class PlotHelper:
         :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
+        :param row: If Figure has multiple subplots, specifies which row
+            to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
+        :param col: If Figure has multiple subplots, specifies which
+            col to use for the plot. Indexing starts at 1. Note that some
+            formatting args (such as figsize) may still be applied to all
+            subplots. Both row and col must be provided together.
         :param kwargs: Passed to go.Heatmap2dContour
 
         :return: Figure object
@@ -1872,12 +1974,13 @@ class PlotHelper:
                                       xbins=dict(size=xbinsize),
                                       ybins=dict(size=ybinsize),
                                       **kwargs)
-        fig.add_trace(trace)
+        fig.add_traces(trace, rows=row, cols=col)
 
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
                                         tick_size, axis_label_size,
-                                        axis_type='noline', margin=margin)
+                                        axis_type='noline', margin=margin,
+                                        row=row, col=col)
 
         return fig
 
@@ -1979,7 +2082,7 @@ class PlotHelper:
                     background = go.Scatter(x=time, y=trace, line=line_kwargs,
                                             showlegend=False, mode='lines',
                                             **kwargs)
-                    fig.add_trace(background, row=r, col=c)
+                    fig.add_traces(background, row=r, col=c)
 
                     # Plot regions of the traces that will be different colors
                     for carr, thres in zip(color_arrays, color_thres):
@@ -1991,7 +2094,7 @@ class PlotHelper:
                                             line=line_kwargs,
                                             showlegend=False, mode='lines',
                                             **kwargs)
-                        fig.add_trace(ctrace, row=r, col=c)
+                        fig.add_traces(ctrace, row=r, col=c)
 
                     trace_idx += 1
                 except IndexError:

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -5,6 +5,7 @@ from typing import Collection, Union, Callable, Generator, Tuple
 
 import numpy as np
 import sklearn.base as base
+import sklearn.metrics as metrics
 import sklearn.preprocessing as preproc
 import scipy.stats as stats
 import matplotlib.colors as mcolors
@@ -1359,6 +1360,7 @@ class PlotHelper:
                      zmax: float = None,
                      robust_z: bool = False,
                      reverse: bool = False,
+                     sort: str = None,
                      figure: Union[go.Figure, go.FigureWidget] = None,
                      figsize: Tuple[int] = (None, None),
                      title: str = None,
@@ -1388,6 +1390,13 @@ class PlotHelper:
         :param robust_z: If True, uses percentiles to set zmin and zmax instead
             of extremes of the dataset.
         :param reverse: If True, the color mapping is reversed.
+        :param sort: If the name of a distance metric, will sort the array
+            according to that metric before producing the heatmap. Valid values
+            are ‘cityblock’, ‘cosine’, ‘euclidean’, ‘l1’, ‘l2’, ‘manhattan’,
+            ‘braycurtis’, ‘canberra’, ‘chebyshev’, ‘correlation’, ‘dice’,
+            ‘hamming’, ‘jaccard’, ‘kulsinski’, ‘mahalanobis’, ‘minkowski’,
+            ‘rogerstanimoto’, ‘russellrao’, ‘seuclidean’, ‘sokalmichener’,
+            ‘sokalsneath’, ‘sqeuclidean’, and ‘yule’.
         :param figure: If a go.Figure object is given, will be used to make
             the plot instead of a blank figure.
         :param figsize: Height and width of the plot in pixels. Must be a tuple
@@ -1425,6 +1434,11 @@ class PlotHelper:
             zmin = np.nanpercentile(array, 2)
             zmax = np.nanpercentile(array, 98)
             zmid = None
+
+        if sort:
+            darr = metrics.pairwise_distances(array, metric=sort)
+            idx = darr[0, :].argsort()
+            array = array[idx]
 
         trace = go.Heatmap(z=array, zmin=zmin, zmax=zmax,
                            zmid=zmid, colorscale=colorscale,

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -137,6 +137,8 @@ class PlotHelper:
                              x_limit: Tuple[float] = None,
                              y_limit: Tuple[float] = None,
                              legend: bool = None,
+                             tick_size: float = None,
+                             axis_label_size: float = None,
                              axis_type: str = 'default',
                              **kwargs
                              ) -> go.Figure:
@@ -169,6 +171,12 @@ class PlotHelper:
             figure_layout.update({'height': figsize[0]})
         if figsize[1] is not None:
             figure_layout.update({'width': figsize[1]})
+        if tick_size is not None:
+            x_axis_layout['tickfont'].update({'size': tick_size})
+            y_axis_layout['tickfont'].update({'size': tick_size})
+        if axis_label_size is not None:
+            x_axis_layout['title']['font'].update({'size': axis_label_size})
+            y_axis_layout['title']['font'].update({'size': axis_label_size})
 
         # Apply changes
         figure.update_layout(**figure_layout, **kwargs)
@@ -363,6 +371,8 @@ class PlotHelper:
                   y_label: str = None,
                   x_limit: Tuple[float] = None,
                   y_limit: Tuple[float] = None,
+                  tick_size: float = None,
+                  axis_label_size: float = None,
                   widget: bool = False,
                   **kwargs
                   ) -> Union[go.Figure, go.FigureWidget]:
@@ -415,6 +425,8 @@ class PlotHelper:
             the plot is saved as an HTML object.
         :param y_limit: Initial limits for the y-axis. Can be changed if
             the plot is saved as an HTML object.
+        :param tick_size: Size of the font of the axis tick labels.
+        :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
         :param kwargs: Depending on name, passed to the "line" keyword
@@ -519,7 +531,8 @@ class PlotHelper:
         # Upate the axes and figure layout
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        legend, axis_type='default')
+                                        legend, tick_size, axis_label_size,
+                                        axis_type='default')
 
         return fig
 
@@ -543,6 +556,8 @@ class PlotHelper:
                      y_label: str = None,
                      x_limit: Tuple[float] = None,
                      y_limit: Tuple[float] = None,
+                     tick_size: float = None,
+                     axis_label_size: float = None,
                      widget: bool = False,
                      **kwargs
                      ) -> Union[go.Figure, go.FigureWidget]:
@@ -598,6 +613,8 @@ class PlotHelper:
             the plot is saved as an HTML object.
         :param y_limit: Initial limits for the y-axis. Can be changed if
             the plot is saved as an HTML object.
+        :param tick_size: Size of the font of the axis tick labels.
+        :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
         :param kwargs: Depending on name, passed to the "marker" keyword
@@ -706,7 +723,8 @@ class PlotHelper:
         # Apply formatting and return
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        legend, axis_type='default')
+                                        legend, tick_size, axis_label_size,
+                                        axis_type='default')
 
         return fig
 
@@ -729,6 +747,8 @@ class PlotHelper:
                  y_label: str = None,
                  x_limit: Tuple[float] = None,
                  y_limit: Tuple[float] = None,
+                 tick_size: float = None,
+                 axis_label_size: float = None,
                  widget: bool = False,
                  **kwargs
                  ) -> Union[go.Figure, go.FigureWidget]:
@@ -781,6 +801,8 @@ class PlotHelper:
         :param y_limit: Initial limits for the y-axis. Can be changed if
             the plot is saved as an HTML object. Only applies if orientation
             is vertical.
+        :param tick_size: Size of the font of the axis tick labels.
+        :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
         :param kwargs: Depending on name, passed to go.Bar or to
@@ -873,7 +895,8 @@ class PlotHelper:
         # Format plot on the way out
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        legend, axis_type='default',
+                                        legend, tick_size, axis_label_size,
+                                        axis_type='default',
                                         barmode=barmode)
         fig.update_traces(**kwargs)
 
@@ -908,6 +931,8 @@ class PlotHelper:
                        y_label: str = None,
                        x_limit: Tuple[float] = None,
                        y_limit: Tuple[float] = None,
+                       tick_size: float = None,
+                       axis_label_size: float = None,
                        widget: bool = False,
                        **kwargs
                        ) -> Union[go.Figure, go.FigureWidget]:
@@ -988,6 +1013,8 @@ class PlotHelper:
         :param y_limit: Initial limits for the y-axis. Can be changed if
             the plot is saved as an HTML object. Only applies if orientation
             is vertical.
+        :param tick_size: Size of the font of the axis tick labels.
+        :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
         :param kwargs: Depending on name, kwargs are passed to either
@@ -1107,7 +1134,8 @@ class PlotHelper:
         # Format plot on the way out
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        legend, axis_type='default',
+                                        legend, tick_size, axis_label_size,
+                                        axis_type='default',
                                         barmode=barmode,
                                         bargap=bargap, bargroupgap=bargroupgap)
 
@@ -1136,6 +1164,8 @@ class PlotHelper:
                     y_label: str = None,
                     x_limit: Tuple[float] = None,
                     y_limit: Tuple[float] = None,
+                    tick_size: float = None,
+                    axis_label_size: float = None,
                     widget: bool = False,
                     **kwargs
                     ) -> Union[go.Figure, go.FigureWidget]:
@@ -1192,6 +1222,8 @@ class PlotHelper:
         :param y_limit: Initial limits for the y-axis. Can be changed if
             the plot is saved as an HTML object. Only applies if orientation
             is veritcal.
+        :param tick_size: Size of the font of the axis tick labels.
+        :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
         :param kwargs: Depending on name, passed to go.Violin or to
@@ -1288,7 +1320,8 @@ class PlotHelper:
         # Format plot on the way out
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        legend, axis_type='default',
+                                        legend, tick_size, axis_label_size,
+                                        axis_type='default',
                                         violinmode=violinmode)
         fig.update_traces(**kwargs)
 
@@ -1312,6 +1345,8 @@ class PlotHelper:
                        y_label: str = None,
                        x_limit: Tuple[float] = None,
                        y_limit: Tuple[float] = None,
+                       tick_size: float = None,
+                       axis_label_size: float = None,
                        widget: bool = False,
                        **kwargs
                        ) -> Union[go.Figure, go.FigureWidget]:
@@ -1356,6 +1391,8 @@ class PlotHelper:
         :param y_limit: Initial limits for the y-axis. Can be changed if
             the plot is saved as an HTML object. Only applies if orientation
             is veritcal.
+        :param tick_size: Size of the font of the axis tick labels.
+        :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
         :param kwargs: Depending on name, passed to go.Violin or to
@@ -1377,7 +1414,7 @@ class PlotHelper:
         # Some settings for making a ridgeline out of the violin plot
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        legend,
+                                        legend, tick_size, axis_label_size,
                                         axis_type='default',
                                         xaxis_showgrid=False,
                                         xaxis_zeroline=False)
@@ -1401,6 +1438,8 @@ class PlotHelper:
                      y_label: str = None,
                      x_limit: Tuple[float] = None,
                      y_limit: Tuple[float] = None,
+                     tick_size: float = None,
+                     axis_label_size: float = None,
                      widget: bool = False,
                      **kwargs
                      ) -> Union[go.Figure, go.FigureWidget]:
@@ -1443,6 +1482,8 @@ class PlotHelper:
         :param y_limit: Initial limits for the y-axis. Can be changed if
             the plot is saved as an HTML object. Only applies if orientation
             is veritcal.
+        :param tick_size: Size of the font of the axis tick labels.
+        :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
         :param kwargs: Passed to go.Heatmap.
@@ -1480,6 +1521,7 @@ class PlotHelper:
 
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
+                                        tick_size, axis_label_size,
                                         axis_type='noline')
 
         return fig
@@ -1503,6 +1545,8 @@ class PlotHelper:
                        y_label: str = None,
                        x_limit: Tuple[float] = None,
                        y_limit: Tuple[float] = None,
+                       tick_size: float = None,
+                       axis_label_size: float = None,
                        widget: bool = False,
                        **kwargs
                        ) -> Union[go.Figure, go.FigureWidget]:
@@ -1560,6 +1604,8 @@ class PlotHelper:
         :param y_limit: Initial limits for the y-axis. Can be changed if
             the plot is saved as an HTML object. Only applies if orientation
             is veritcal.
+        :param tick_size: Size of the font of the axis tick labels.
+        :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
         :param kwargs: Passed to go.Histogram2d.
@@ -1597,6 +1643,7 @@ class PlotHelper:
 
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
+                                        tick_size, axis_label_size,
                                         axis_type='noline')
 
         return fig
@@ -1620,6 +1667,8 @@ class PlotHelper:
                        y_label: str = None,
                        x_limit: Tuple[float] = None,
                        y_limit: Tuple[float] = None,
+                       tick_size: float = None,
+                       axis_label_size: float = None,
                        widget: bool = False,
                        **kwargs
                        ) -> Union[go.Figure, go.FigureWidget]:
@@ -1677,6 +1726,8 @@ class PlotHelper:
         :param y_limit: Initial limits for the y-axis. Can be changed if
             the plot is saved as an HTML object. Only applies if orientation
             is veritcal.
+        :param tick_size: Size of the font of the axis tick labels.
+        :param axis_label_size: Size of the font of the axis label.
         :param widget: If True, returns a go.FigureWidget object instead of
             a go.Figure object.
         :param kwargs: Passed to go.Heatmap2dContour
@@ -1714,6 +1765,7 @@ class PlotHelper:
 
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
+                                        tick_size, axis_label_size,
                                         axis_type='noline')
 
         return fig

--- a/celltk/utils/plot_utils.py
+++ b/celltk/utils/plot_utils.py
@@ -136,6 +136,7 @@ class PlotHelper:
                              y_label: str = None,
                              x_limit: Tuple[float] = None,
                              y_limit: Tuple[float] = None,
+                             legend: bool = None,
                              axis_type: str = 'default',
                              **kwargs
                              ) -> go.Figure:
@@ -152,6 +153,8 @@ class PlotHelper:
         figure_layout = {'template': deepcopy(self._template)}
 
         # Updates only made if not None, preserves old values
+        if legend is not None:
+            figure_layout.update({'showlegend': legend})
         if x_label is not None:
             x_axis_layout['title'].update({'text': x_label})
         if y_label is not None:
@@ -492,7 +495,7 @@ class PlotHelper:
         # Upate the axes and figure layout
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        axis_type='default')
+                                        legend, axis_type='default')
 
         return fig
 
@@ -503,6 +506,7 @@ class PlotHelper:
                      estimator: Union[Callable, str, functools.partial] = None,
                      err_estimator: Union[Callable, str, functools.partial] = None,
                      normalizer: Union[Callable, str] = None,
+                     scatter_mode: str = 'markers',
                      colors: Union[str, Collection[str]] = None,
                      alpha: float = 1.0,
                      symbols: Union[str, Collection[str]] = None,
@@ -549,6 +553,8 @@ class PlotHelper:
             the estimators. Normalizes the error as well. Can be 'minmax' or
             'maxabs', or a callable that inputs an array and outputs an array
             of the same shape.
+        :param scatter_mode: Drawing mode for the traces. Can be 'markers',
+            'lines', or 'lines+markers'.
         :param colors: Name of a color palette or map to use. Searches first
             in seaborn/matplotlib, then in Plotly to find the color map. If
             not provided, the color map will be glasbey. Can also be list
@@ -666,7 +672,7 @@ class PlotHelper:
                                       symbol=next(symbols)))
             traces.append(
                 go.Scatter(x=x, y=y, legendgroup=key, name=key,
-                           showlegend=legend, mode='markers',
+                           showlegend=legend, mode=scatter_mode,
                            error_x=error_x, error_y=error_y,
                            marker=marker_kwargs, **kwargs)
             )
@@ -676,7 +682,7 @@ class PlotHelper:
         # Apply formatting and return
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        axis_type='default')
+                                        legend, axis_type='default')
 
         return fig
 
@@ -843,7 +849,8 @@ class PlotHelper:
         # Format plot on the way out
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        axis_type='default', barmode=barmode)
+                                        legend, axis_type='default',
+                                        barmode=barmode)
         fig.update_traces(**kwargs)
 
         return fig
@@ -1076,7 +1083,8 @@ class PlotHelper:
         # Format plot on the way out
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        axis_type='default', barmode=barmode,
+                                        legend, axis_type='default',
+                                        barmode=barmode,
                                         bargap=bargap, bargroupgap=bargroupgap)
 
         return fig
@@ -1256,7 +1264,7 @@ class PlotHelper:
         # Format plot on the way out
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
-                                        axis_type='default',
+                                        legend, axis_type='default',
                                         violinmode=violinmode)
         fig.update_traces(**kwargs)
 
@@ -1345,6 +1353,7 @@ class PlotHelper:
         # Some settings for making a ridgeline out of the violin plot
         fig = self._apply_format_figure(fig, figsize, title,
                                         x_label, y_label, x_limit, y_limit,
+                                        legend,
                                         axis_type='default',
                                         xaxis_showgrid=False,
                                         xaxis_zeroline=False)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2022, Stevan Jeknic'
 author = 'Stevan Jeknic'
 
 # The full version, including alpha/beta/rc tags
-release = '0.4.1'
+release = '0.4.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,9 @@ CellTK is collection of tools to simplify working with live-cell and fixed-cell 
 
 Installation
 ------------
-A package will be published soon. In the meantime, please use the following steps to install and run CellTK.
+The easiest way to install CellTK is to use pip.
 
-| ``git clone https://github.com/sjeknic/CellTK/``
-| ``pip install -r requirements.txt``
+| ``pip install celltk2``
 
 That's it! You should be good to go. If you run into any problems, please open an issue on github.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "celltk2"
-version = "0.4.1"
+version = "0.4.2"
 authors = [{name="sjeknic", email="sjeknic@stanford.edu"}]
 description = "A toolkit for analysis of live-cell microscopy images"
 readme = "README.md"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="celltk",
-    version="0.4.1",
+    version="0.4.2",
     author="Stevan Jeknic",
     author_email="sjeknic@stanford.edu",
     description="A tool kit for working with large amounts of live-cell microscopy data.",


### PR DESCRIPTION
This PR provides a number of improvements, primarily for producing plots.
Changes not related to plots: 
- `_ArrayHolder` now has magic methods to handle addition, subtraction, etc. Thus, it is easier to index data from an `ExperimentArray` and then modify those data in some way for all keys. List comprehensions no longer required.
- Function added to `Process` for cropping stacks down to an arbitrary area.
- `PeakHelper` can now do a basic peak width calculation. Returns `nan` if the trace does not pass the desired target height. No estimation included.

Plotting changes:
- Subplots are now supported. The figure with subplots must be made first (i.e. `go.Figure().set_subplots`) and passed to the plotting function. 
- `bootstrap_estimator` can now use an arbitrary function.
- Heatmap plots can be sorted on an arbitrary distance metric (e.g. euclidean, cosine, etc.)
- Fixed a bug where certain colors weren't rendering properly.
- Option to set axis label and tick label size directly in the plotting function.
- Margins are handled directly in the plotting function. Makes it easier to consistently set the size of the plotting area.